### PR TITLE
fixed grid effect

### DIFF
--- a/modulus/datapipes/benchmarks/darcy.py
+++ b/modulus/datapipes/benchmarks/darcy.py
@@ -257,21 +257,22 @@ class Darcy2D(Datapipe):
                 if normalized_inf_residual < (
                     self.convergence_threshold * grid_reduction_factor
                 ):
-
-                    # upsample to higher resolution
-                    if grid_reduction_factor > 1:
-                        wp.launch(
-                            kernel=bilinear_upsample_batched_2d,
-                            dim=self.dim,
-                            inputs=[
-                                self.darcy0,
-                                self.dim[1],
-                                self.dim[2],
-                                grid_reduction_factor,
-                            ],
-                            device=self.device,
-                        )
                     break
+
+            # upsample to higher resolution
+            if grid_reduction_factor > 1:
+                wp.launch(
+                    kernel=bilinear_upsample_batched_2d,
+                    dim=self.dim,
+                    inputs=[
+                        self.darcy0,
+                        self.dim[1],
+                        self.dim[2],
+                        grid_reduction_factor,
+                    ],
+                    device=self.device,
+                )
+ 
 
     def __iter__(self) -> Tuple[Tensor, Tensor]:
         """


### PR DESCRIPTION
There was an issue that comes up when the max iterations is reached without convergence. This causes the upsampling to not be applied in the next higher grid resolution. This causes some checkerboard effects although as long as the convergence threshold is kept at the default this should not cause any issue to begin with.