### PR TITLE
Torch harmonics dependency fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "zarr>=2.14.2",
     "s3fs>=2023.5.0",
     "benchy@git+https://github.com/romerojosh/benchy.git#egg=1aade4a412fe883e45927183d3e5a0cc9fe14b30",
-    "torch-harmonics@git+https://github.com/NVIDIA/torch-harmonics.git@8826246cacf6c37b600cdd63fde210815ba238fd",
+    "torch_harmonics@git+https://github.com/NVIDIA/torch-harmonics.git@8826246cacf6c37b600cdd63fde210815ba238fd",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "zarr>=2.14.2",
     "s3fs>=2023.5.0",
     "benchy@git+https://github.com/romerojosh/benchy.git#egg=1aade4a412fe883e45927183d3e5a0cc9fe14b30",
-    "torch-harmonics@git+https://github.com/NVIDIA/torch-harmonics.git#egg=8826246cacf6c37b600cdd63fde210815ba238fd",
+    "torch-harmonics@git+https://github.com/NVIDIA/torch-harmonics.git@8826246cacf6c37b600cdd63fde210815ba238fd",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixing issue with git version locking for torch harmonics dependency

Original version was ignoring the git sha for torch-harmonics
```
Collecting torch-harmonics@ git+https://github.com/NVIDIA/torch-harmonics.git#egg=8826246cacf6c37b600cdd63fde210815ba238fd (from nvidia-modulus==0.1.0)
  Cloning https://github.com/NVIDIA/torch-harmonics.git to /tmp/pip-install-840mn0gu/torch-harmonics_b52de40f1bbf416cbff12df2f60b44cb
  Running command git clone --filter=blob:none --quiet https://github.com/NVIDIA/torch-harmonics.git /tmp/pip-install-840mn0gu/torch-harmonics_b52de40f1bbf416cbff12df2f60b44cb
  Resolved https://github.com/NVIDIA/torch-harmonics.git to commit 786750f859e0e47d82a43bebe1e602539f59d373
```

Changes here fix that issue and respect the requested git sha:
```
Collecting torch-harmonics@ git+https://github.com/NVIDIA/torch-harmonics.git@8826246cacf6c37b600cdd63fde210815ba238fd (from nvidia-modulus==0.1.0)
  Cloning https://github.com/NVIDIA/torch-harmonics.git (to revision 8826246cacf6c37b600cdd63fde210815ba238fd) to /tmp/pip-install-mawmu4hg/torch-harmonics_fde659ad003c4ef88775f4f68abb7327
  Running command git clone --filter=blob:none --quiet https://github.com/NVIDIA/torch-harmonics.git /tmp/pip-install-mawmu4hg/torch-harmonics_fde659ad003c4ef88775f4f68abb7327
  Running command git rev-parse -q --verify 'sha^8826246cacf6c37b600cdd63fde210815ba238fd'
  Running command git fetch -q https://github.com/NVIDIA/torch-harmonics.git 8826246cacf6c37b600cdd63fde210815ba238fd
  Running command git checkout -q 8826246cacf6c37b600cdd63fde210815ba238fd
  Resolved https://github.com/NVIDIA/torch-harmonics.git to commit 8826246cacf6c37b600cdd63fde210815ba238fd
  Preparing metadata (setup.py) ... done
```