### PR TITLE
Hot-fix NCCL CUDA Graphs bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Version
       description: What version of Modulus are you running?
-      placeholder: "example: 0.2.0"
+      placeholder: "example: 0.2.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
+## [0.2.1] - 2023-08-xx
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Added a workaround fix for the CUDA graphs error in multi-node runs
+
+### Security
+
+### Dependencies
+
 ## [0.2.0] - 2023-08-xx
 
 ### Added

--- a/modulus/__init__.py
+++ b/modulus/__init__.py
@@ -19,4 +19,4 @@ from .datapipes.meta import DatapipeMetaData
 
 from .datapipes.datapipe import Datapipe
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/modulus/utils/capture.py
+++ b/modulus/utils/capture.py
@@ -114,7 +114,6 @@ class _StaticCapture(object):
             scaler_enabled = self.use_gradscaler and amp_type == torch.float16
             self.scaler = self._init_amp_scaler(scaler_enabled, self.logger)
 
-            # self.replay_stream = torch.cuda.current_stream(self.model.device)
             self.replay_stream = torch.cuda.Stream(self.model.device)
         # CPU device
         else:
@@ -180,7 +179,6 @@ class _StaticCapture(object):
         """
         # Graph warm up
         if self.iteration < self.cuda_graph_warmup:
-            # warmup_stream = torch.cuda.Stream()
             self.replay_stream.wait_stream(torch.cuda.current_stream())
             self._zero_grads()
             with torch.cuda.stream(self.replay_stream):

--- a/modulus/utils/capture.py
+++ b/modulus/utils/capture.py
@@ -198,7 +198,7 @@ class _StaticCapture(object):
                     torch.distributed.barrier()
                 # TODO: temporary workaround till this issue is fixed:
                 # https://github.com/pytorch/pytorch/pull/104487#issuecomment-1638665876
-                delay = os.environ.get("MODULUS_CUDA_GRAPH_CAPTURE_DELAY", "30")
+                delay = os.environ.get("MODULUS_CUDA_GRAPH_CAPTURE_DELAY", "10")
                 time.sleep(int(delay))
                 with torch.cuda.graph(self.graph):
                     output = self._amp_forward(*args, **kwargs)


### PR DESCRIPTION
# Modulus Pull Request

## Description
Closes #107 

The workaround fix adds a time delay between the warmup steps and the start of the graph capture to allow enough time for NCCL watchdog to clean-up work. The fix was stress tested against AFNO example from Modulus Launch, and it passed 10/10 times. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is
up to date with these changes.

## Dependencies

<!-- Call out any new dependencies needed if any -->