### PR TITLE
Refactor DLWP wrapper and add batching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added distributed utilities to create process groups and orthogonal process groups.
 - Added distributed AFNO model implementation.
+- Added batching support and fix the input time step for the DLWP wrapper.
 
 ### Changed
 

--- a/modulus/models/fcn_mip_plugin.py
+++ b/modulus/models/fcn_mip_plugin.py
@@ -173,7 +173,11 @@ class _DLWPWrapper(torch.nn.Module):
         for i in range(len(input_list)):
             tisr = np.maximum(
                 cos_zenith_angle(
-                    time + datetime.timedelta(hours=6 * i), self.longrid, self.latgrid
+                    time
+                    - datetime.timedelta(hours=6 * (input.shape[0] - 1))
+                    + datetime.timedelta(hours=6 * i),
+                    self.longrid,
+                    self.latgrid,
                 ),
                 0,
             ) - (

--- a/modulus/models/fcn_mip_plugin.py
+++ b/modulus/models/fcn_mip_plugin.py
@@ -155,6 +155,17 @@ class _DLWPWrapper(torch.nn.Module):
         self.topographic_height = topographic_height
 
         # load map weights
+        # Note: these map files are created using TempestRemap library
+        # https://github.com/ClimateGlobalChange/tempestremap
+        # To generate the maps, the below sequence of commands can be
+        # executed once TempestRemap is installed.
+
+        # GenerateRLLMesh --lat 721 --lon 1440 --file out_latlon.g --lat_begin 90 --lat_end -90 --out_format Netcdf4
+        # GenerateCSMesh --res <desired-res> --file out_cubedsphere.g --out_format Netcdf4
+        # GenerateOverlapMesh --a out_latlon.g --b out_cubedsphere.g --out overlap_latlon_cubedsphere.g --out_format Netcdf4
+        # GenerateOfflineMap --in_mesh out_latlon.g --out_mesh out_cubedsphere.g --ov_mesh overlap_latlon_cubedsphere.g --in_np 1 --in_type FV --out_type FV --out_map map_LL_CS.nc --out_format Netcdf4
+        # GenerateOverlapMesh --a out_cubedsphere.g --b out_latlon.g --out overlap_cubedsphere_latlon.g --out_format Netcdf4
+        # GenerateOfflineMap --in_mesh out_cubedsphere.g --out_mesh out_latlon.g --ov_mesh overlap_cubedsphere_latlon.g --in_np 1 --in_type FV --out_type FV --out_map map_CS_LL.nc --out_format Netcdf4
         self.input_map_wts = xarray.open_dataset(ll_to_cs_mapfile_path)
         self.output_map_wts = xarray.open_dataset(cs_to_ll_mapfile_path)
 

--- a/modulus/models/fcn_mip_plugin.py
+++ b/modulus/models/fcn_mip_plugin.py
@@ -159,17 +159,17 @@ class _DLWPWrapper(torch.nn.Module):
     def prepare_input(self, input, time):
         device = input.device
         dtype = input.dtype
-        num_chans = input.size(2)
-        input_list = list(torch.split(input, 1, dim=1))
+
         i = self.input_map_wts.row.values - 1
         j = self.input_map_wts.col.values - 1
         data = self.input_map_wts.S.values
-        M = torch.sparse_coo_tensor(np.array((i, j)), data).to(device).type(dtype)
+        M = torch.sparse_coo_tensor(np.array((i, j)), data).type(dtype).to(device)
 
-        for i in range(len(input_list)):
-            input_list[i] = input_list[i].reshape(num_chans, -1) @ M.T
-            input_list[i] = input_list[i].reshape(1, num_chans, 6, 64, 64)
-
+        input = input.reshape(input.shape[0], input.shape[1], input.shape[2], -1) @ M.T
+        input = input.reshape(input.shape[0], input.shape[1], input.shape[2], 6, 64, 64)
+        input_list = list(torch.split(input, 1, dim=1))
+        input_list = [tensor.squeeze(1) for tensor in input_list]
+        repeat_vals = (input.shape[0], -1, -1, -1, -1)  # repeat along batch dimension
         for i in range(len(input_list)):
             tisr = np.maximum(
                 cos_zenith_angle(
@@ -185,6 +185,7 @@ class _DLWPWrapper(torch.nn.Module):
                 .unsqueeze(dim=0)
                 .unsqueeze(dim=0)
             )  # add channel and batch size dimension
+            tisr = tisr.expand(*repeat_vals)  # TODO - find better way to batch TISR
             input_list[i] = torch.cat(
                 (input_list[i], tisr), dim=1
             )  # concat along channel dim
@@ -192,7 +193,7 @@ class _DLWPWrapper(torch.nn.Module):
         input_model = torch.cat(
             input_list, dim=1
         )  # concat the time dimension into channels
-        repeat_vals = (1, -1, -1, -1, -1)  # repeat along batch dimension
+
         lsm_tensor = torch.tensor(self.lsm, dtype=dtype).to(device).unsqueeze(dim=0)
         lsm_tensor = lsm_tensor.expand(*repeat_vals)
         topographic_height_tensor = (
@@ -205,7 +206,6 @@ class _DLWPWrapper(torch.nn.Module):
         input_model = torch.cat(
             (input_model, lsm_tensor, topographic_height_tensor), dim=1
         )
-
         return input_model
 
     def prepare_output(self, output):
@@ -213,17 +213,13 @@ class _DLWPWrapper(torch.nn.Module):
         dtype = output.dtype
         output = torch.split(output, output.shape[1] // 2, dim=1)
         output = torch.stack(output, dim=1)  # add time dimension back in
-        output_list = list(torch.split(output, 1, dim=1))
-        num_chans = output_list[0].shape[2]
         i = self.output_map_wts.row.values - 1
         j = self.output_map_wts.col.values - 1
         data = self.output_map_wts.S.values
-        M = torch.sparse_coo_tensor(np.array((i, j)), data).to(device).type(dtype)
+        M = torch.sparse_coo_tensor(np.array((i, j)), data).type(dtype).to(device)
 
-        for i in range(len(output_list)):
-            output_list[i] = output_list[i].reshape(num_chans, -1) @ M.T
-            output_list[i] = output_list[i].reshape(1, num_chans, 721, 1440)
-        output = torch.stack(output_list, dim=1)
+        output = output.reshape(output.shape[0], 2, output.shape[2], -1) @ M.T
+        output = output.reshape(output.shape[0], 2, output.shape[2], 721, 1440)
 
         return output
 

--- a/modulus/models/fcn_mip_plugin.py
+++ b/modulus/models/fcn_mip_plugin.py
@@ -168,7 +168,7 @@ class _DLWPWrapper(torch.nn.Module):
         M = torch.sparse_coo_tensor(np.array((i, j)), data).type(dtype).to(device)
 
         N, T, C = input.shape[0], input.shape[1], input.shape[2]
-        input = input.reshape(N * T * C, -1) @ M.T
+        input = (M @ input.reshape(N * T * C, -1).T).T
         S = int((M.shape[0] / 6) ** 0.5)
         input = input.reshape(N, T, C, 6, S, S)
         input_list = list(torch.split(input, 1, dim=1))
@@ -227,7 +227,7 @@ class _DLWPWrapper(torch.nn.Module):
         M = torch.sparse_coo_tensor(np.array((i, j)), data).type(dtype).to(device)
 
         N, T, C = output.shape[0], 2, output.shape[2]
-        output = output.reshape(N * T * C, -1) @ M.T
+        output = (M @ output.reshape(N * T * C, -1).T).T
         output = output.reshape(N, T, C, 721, 1440)
 
         return output

--- a/modulus/models/fcn_mip_plugin.py
+++ b/modulus/models/fcn_mip_plugin.py
@@ -189,7 +189,7 @@ class _DLWPWrapper(torch.nn.Module):
             tisr = np.maximum(
                 cos_zenith_angle(
                     time
-                    - datetime.timedelta(hours=6 * (input.shape[0] - 1))
+                    - datetime.timedelta(hours=6 * (input.shape[1] - 1))
                     + datetime.timedelta(hours=6 * i),
                     self.longrid,
                     self.latgrid,

--- a/test/models/test_fcn_mip_plugin.py
+++ b/test/models/test_fcn_mip_plugin.py
@@ -129,13 +129,15 @@ def save_untrained_dlwp(path):
     return package
 
 
-def test_dlwp(tmp_path):
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_dlwp(tmp_path, batch_size, device):
     package = save_untrained_dlwp(tmp_path)
     source_dir = "/data/nfs/modulus-data/plugin_data/dlwp/"
     _copy_directory(source_dir, tmp_path)
 
-    model = dlwp(package, pretrained=True)
-    x = torch.ones(1, 2, 7, 721, 1440)
+    model = dlwp(package, pretrained=True).to(device)
+    x = torch.ones(batch_size, 2, 7, 721, 1440).to(device)
     time = datetime.datetime(2018, 1, 1)
     with torch.no_grad():
         out = model(x, time)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
This PR adds batching support for the DLWP wrapper needed for faster inference and also updates the time stepping such that the time passed to the wrapper is now corresponds to the latest timestep input to the model. 

Closes #137 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->