### PR TITLE
Use safer tar extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Handle the tar ball extracts in a safer way.
+
 ### Dependencies
 
 - Updated the base container to latest PyTorch 23.07.


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Closes #127 

Specifying the members converts the severity to low as per [bandit docs](https://bandit.readthedocs.io/en/1.7.5/plugins/b202_tarfile_unsafe_members.html)

Checks the members before extracting such that the members:
* Don't try to traverse up the directory structure.
* Don't specify an absolute path to target arbitrary locations on the file system.
* Will be extracted within the intended target directory, even after resolving symbolic links and redundant path elements.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->