### PR TITLE
Hot fix dockerfile deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update && \
 
 ENV _CUDA_COMPAT_TIMEOUT=90
 
+# Install other dependencies
+RUN pip install "h5py>=3.7.0" "mpi4py>=3.1.4" "netcdf4>=1.6.3" "ruamel.yaml>=0.17.22" "scikit-learn>=1.0.2" 
 # TODO remove benchy dependency
 RUN pip install git+https://github.com/romerojosh/benchy.git
 # TODO use torch-harmonics pip package after the upgrade
@@ -94,7 +96,7 @@ FROM builder as ci
 ARG TARGETPLATFORM
 
 COPY . /modulus/
-RUN cd /modulus/ && pip install -e .[all] && pip uninstall nvidia-modulus -y && rm -rf /modulus/
+RUN cd /modulus/ && pip install -e . && pip uninstall nvidia-modulus -y && rm -rf /modulus/
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
 	echo "Installing tensorflow and warp-lang for: $TARGETPLATFORM" && \
 	pip install "tensorflow==2.9.0" "warp-lang>=0.6.0"; \ 
@@ -106,7 +108,7 @@ RUN pip install "black==22.10.0" "interrogate==1.5.0" "coverage==6.5.0" "protobu
 # Deployment image
 FROM builder as deploy
 COPY . /modulus/
-RUN cd /modulus/ && pip install .[all]
+RUN cd /modulus/ && pip install .
 RUN pip install "protobuf==3.20.3"
 
 # Clean up


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Fix installs in dockerfile, specifically, `pip install .[all]` will not work in Dockerfile because that will install warp-lang. We cannot include warp-lang in the release container due to license concerns. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->