### PR TITLE
Updates and Optimizes Wasserstein / FID metrics

### DIFF
--- a/modulus/metrics/diffusion/fid.py
+++ b/modulus/metrics/diffusion/fid.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from scipy.linalg import sqrtm
+import torch
+
+from modulus.metrics.general.wasserstein import wasserstein_from_normal
 
 
 def calculate_fid_from_inception_stats(
-    mu: np.ndarray, sigma: np.ndarray, mu_ref: np.ndarray, sigma_ref: np.ndarray
-) -> float:
+    mu: torch.Tensor, sigma: torch.Tensor, mu_ref: torch.Tensor, sigma_ref: torch.Tensor
+) -> torch.Tensor:
     """
     Calculate the Fréchet Inception Distance (FID) between two sets
     of Inception statistics.
@@ -29,13 +30,13 @@ def calculate_fid_from_inception_stats(
 
     Parameters
     ----------
-    mu:  np.ndarray:
+    mu:  torch.Tensor:
         Mean of Inception statistics for the generated dataset.
-    sigma: np.ndarray:
+    sigma: torch.Tensor:
         Covariance matrix of Inception statistics for the generated dataset.
-    mu_ref: np.ndarray
+    mu_ref: torch.Tensor
         Mean of Inception statistics for the reference dataset.
-    sigma_ref: np.ndarray
+    sigma_ref: torch.Tensor
         Covariance matrix of Inception statistics for the reference dataset.
 
     Returns
@@ -43,7 +44,4 @@ def calculate_fid_from_inception_stats(
     float
         The Fréchet Inception Distance (FID) between the two datasets.
     """
-    m = np.square(mu - mu_ref).sum()
-    s, _ = sqrtm(np.dot(sigma, sigma_ref), disp=False)
-    fid = m + np.trace(sigma + sigma_ref - s * 2)
-    return float(np.real(fid))
+    return wasserstein_from_normal(mu, sigma, mu_ref, sigma_ref)

--- a/modulus/metrics/general/wasserstein.py
+++ b/modulus/metrics/general/wasserstein.py
@@ -12,12 +12,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from warnings import warn
+
 import torch
+
+from modulus.metrics.general import histogram
 
 Tensor = torch.Tensor
 
 
-def wasserstein(bin_edges: Tensor, cdf_x: Tensor, cdf_y: Tensor) -> Tensor:
+def wasserstein_from_normal(
+    mu0: Tensor, sigma0: Tensor, mu1: Tensor, sigma1: Tensor
+) -> Tensor:
+    """Compute the wasserstein distances between two (possibly multivariate) normal
+    distributions.
+
+    Parameters
+    ----------
+    mu0 : Tensor [B (optional), d1]
+        The mean of distribution 0. Can optionally have a batched first dimension.
+    sigma0 : Tensor [B (optional), d1, d2 (optional)]
+        The variance or covariance of distribution 0. If mu0 has a batched dimension,
+        then so must sigma0. If sigma0 is 2 dimension, it is assumed to be a covariance matrix
+        and must be symmetric positive definite.
+    mu1 : Tensor [B (optional), d1]
+        The mean of distribution 1. Can optionally have a batched first dimension.
+    sigma1 : Tensor [B (optional), d1, d2 (optional)]
+        The variance or covariance of distribution 1. If mu1 has a batched dimension,
+        then so must sigma1. If sigma1 is 2 dimension, it is assumed to be a covariance matrix
+        and must be symmetric positive definite.
+
+    Returns
+    -------
+    Tensor [B]
+        The wasserstein distance between N(mu0, sigma0) and N(mu1, sigma1)
+    """
+    mu_ndim = mu0.ndim
+    sigma_ndim = sigma0.ndim
+    if sigma_ndim == mu_ndim:
+        # Univariate normal distribution
+        return (mu0 - mu1) ** 2 + (sigma0 + sigma1 - 2 * torch.sqrt(sigma0 * sigma1))
+
+    else:
+        # Multivariate normal distribution
+        # Compute trace(sig0 + sig1 - 2*(sig0^1/2 * sig1 * sig0^1/2)^1/2) first
+
+        # Compute sig0^1/2 first using eigen decomposition.
+        vals0, vecs0 = torch.linalg.eigh(sigma0)
+        if torch.any(vals0 < 0.0):
+            warn(
+                "Warning! Some eigenvalues are less than zero and matrix is not positive definite."
+            )
+            vals0 = torch.nn.functional.relu(vals0)
+        sqrt_sig0 = torch.matmul(
+            torch.matmul(vecs0, torch.diag_embed(torch.sqrt(vals0))),
+            vecs0.transpose(-2, -1),
+        )
+
+        # Compute C = (sig0^1/2 * sig1 * sig0^1/2)
+        C = torch.matmul(torch.matmul(sqrt_sig0, sigma1), sqrt_sig0)
+
+        # Compute Csqrt = sqrt( C )
+        vals0, vecs0 = torch.linalg.eigh(C)
+        if torch.any(vals0 < 0.0):
+            warn(
+                "Warning! Some eigenvalues are less than zero and matrix is not positive definite."
+            )
+            vals0 = torch.nn.functional.relu(vals0)
+        sqrtC = torch.matmul(
+            torch.matmul(vecs0, torch.diag_embed(torch.sqrt(vals0))),
+            vecs0.transpose(-2, -1),
+        )
+
+        # Compute T = tr(sig0 + sig1 - 2* sqrtC)
+        if sigma_ndim > 2:
+            T = torch.vmap(torch.trace)(sigma0 + sigma1 - 2 * sqrtC)
+        else:
+            T = torch.trace(sigma0 + sigma1 - 2 * sqrtC)
+
+        return torch.norm((mu0 - mu1), p=2, dim=-1) ** 2 + T
+
+
+def wasserstein_from_samples(x: Tensor, y: Tensor, bins: int = 10):
+    """1-Wasserstein distances between two sets of samples, computed using
+    the discrete CDF.
+
+    Parameters
+    ----------
+    x : Tensor [S, ...]
+        Tensor containing one set of samples. The wasserstein metric will be computed
+        over the first dimension of the data.
+    y : Tensor[S, ...]
+        Tensor containing the second set of samples. The wasserstein metric will be computed
+        over the first dimension of the data. The shapes of x and y must be compatible.
+    bins : int, Optional.
+        Optional number of bins to use in the empirical CDF. Defaults to 10.
+
+    Returns
+    -------
+    Tensor
+        The 1-Wasserstein distance between the samples x and y.
+    """
+    bin_edges, cdf_x = histogram.cdf(x, bins=bins)
+    _, cdf_y = histogram.cdf(y, bins=bin_edges)
+    return wasserstein_from_cdf(bin_edges, cdf_x, cdf_y)
+
+
+def wasserstein_from_cdf(bin_edges: Tensor, cdf_x: Tensor, cdf_y: Tensor) -> Tensor:
     """1-Wasserstein distance between two discrete CDF functions
 
     This norm is typically used to compare two different forecast ensembles (for X and

--- a/test/metrics/diffusion/test_fid.py
+++ b/test/metrics/diffusion/test_fid.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 
-import numpy as np
 import pytest
+import torch
 
 from modulus.metrics.diffusion import calculate_fid_from_inception_stats
 
 
 def test_fid_calculation():
-    mu = np.array([1.0, 2.0])
-    sigma = np.array([[1.0, 0.5], [0.5, 2.0]])
-    mu_ref = np.array([0.0, 1.0])
-    sigma_ref = np.array([[2.0, 0.3], [0.3, 1.5]])
+    mu = torch.Tensor([1.0, 2.0])
+    sigma = torch.Tensor([[1.0, 0.5], [0.5, 2.0]])
+    mu_ref = torch.Tensor([0.0, 1.0])
+    sigma_ref = torch.Tensor([[2.0, 0.3], [0.3, 1.5]])
 
     fid = calculate_fid_from_inception_stats(mu, sigma, mu_ref, sigma_ref)
     expected_fid = 2.234758220608337


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Replaces the existing frechet inception distance (FID) metric, which used scipy's `sqrtm` function with a general purpose Wasserstein 2 metric written in pytorch. The new function is more stable than the previous implementation because it makes assumptions about positive definite matrices for better matrix square roots. It also adds overloading for W2/FID calculations for (batched) univariate and multivariate cases. 

Closes #205 

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->