### PR TITLE
Adding NGC model file support to filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ruff as a linting tool.
 - Ported utilities from Modulus Launch to main package.
 - EDM diffusion models and recipes for training and sampling.
+- NGC model registry download integration into package/filesystem.
 
 ### Changed
 

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -102,7 +102,7 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
         total_size_in_bytes = int(r.headers.get("content-length", 0))
         chunk_size = 1024  # 1 kb
         progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
-        progress_bar.set_description(f"Downloading {filename}")
+        progress_bar.set_description(f"NGC file {filename}")
         with open(local_url, "wb") as f:
             for chunk in r.iter_content(chunk_size=chunk_size):
                 progress_bar.update(len(chunk))

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -102,7 +102,7 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
         total_size_in_bytes = int(r.headers.get("content-length", 0))
         chunk_size = 1024  # 1 kb
         progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
-        progress_bar.set_description("Downloading NGC model file")
+        progress_bar.set_description(f"Downloading {filename}")
         with open(local_url, "wb") as f:
             for chunk in r.iter_content(chunk_size=chunk_size):
                 progress_bar.update(len(chunk))

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -102,7 +102,7 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
         total_size_in_bytes = int(r.headers.get("content-length", 0))
         chunk_size = 1024  # 1 kb
         progress_bar = tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
-        progress_bar.set_description(f"NGC file {filename}")
+        progress_bar.set_description(f"Fetching {filename}")
         with open(local_url, "wb") as f:
             for chunk in r.iter_content(chunk_size=chunk_size):
                 progress_bar.update(len(chunk))

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -89,7 +89,9 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
             r.raise_for_status()
             token = json.loads(r.content)["token"]
         except requests.exceptions.RequestException:
-            logger.warning("Failed to get JWT using the API set in NGC_API_KEY")
+            logger.warning(
+                "Failed to get JWT using the API set in NGC_API_KEY environment variable"
+            )
             raise  # Re-raise the exception
 
     # Download file, apparently the URL for private registries is different than the public?

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -74,7 +74,7 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
             session = requests.Session()
             session.auth = ("$oauthtoken", os.environ["API_KEY"])
             headers = {"Accept": "application/json"}
-            authn_url = "https://authn.nvidia.com/token?service=ngc&scope=group/ngc:{org}&group/ngc:{org}/{team}"
+            authn_url = f"https://authn.nvidia.com/token?service=ngc&scope=group/ngc:{org}&group/ngc:{org}/{team}"
             r = session.get(authn_url, headers=headers, timeout=5)
             r.raise_for_status()
             token = json.loads(r.content)["token"]

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -121,11 +121,13 @@ def _download_ngc_model_file(path: str, out_path: str, timeout: int = 300) -> st
     return out_path
 
 
-def _download_cached(path: str, recursive: bool = False) -> str:
+def _download_cached(
+    path: str, recursive: bool = False, local_cache_path: str = LOCAL_CACHE
+) -> str:
     sha = hashlib.sha256(path.encode())
     filename = sha.hexdigest()
     try:
-        os.makedirs(LOCAL_CACHE, exist_ok=True)
+        os.makedirs(local_cache_path, exist_ok=True)
     except PermissionError as error:
         logger.error(
             "Failed to create cache folder, check permissions or set a cache"
@@ -139,7 +141,7 @@ def _download_cached(path: str, recursive: bool = False) -> str:
         )
         raise error
 
-    cache_path = os.path.join(LOCAL_CACHE, filename)
+    cache_path = os.path.join(local_cache_path, filename)
 
     url = urllib.parse.urlparse(path)
 

--- a/modulus/utils/filesystem.py
+++ b/modulus/utils/filesystem.py
@@ -179,12 +179,23 @@ def _download_cached(
 
 
 class Package:
-    """A package
+    """A generic file system abstraction. Can be used to represent local and remote
+    file systems. Remote files are automatically fetched and stored in the
+    $LOCAL_CACHE or $HOME/.cache/modulus folder. The `get` method can then be used
+    to access files present.
 
-    Represents a potentially remote directory tree
+    Presently one can use Package with the following directories:
+    - Package("/path/to/local/directory") = local file system
+    - Package("s3://bucket/path/to/directory") = object store file system
+    - Package("http://url/path/to/directory") = http file system
+    - Package("ngc://model/<org_id/team_id/model_id>@<version>") = ngc model file system
+
+    Args:
+        root (str): Root directory for file system
+        seperator (str, optional): directory seperator. Defaults to "/".
     """
 
-    def __init__(self, root: str, seperator: str):
+    def __init__(self, root: str, seperator: str = "/"):
         self.root = root
         self.seperator = seperator
 

--- a/test/utils/test_filesystem.py
+++ b/test/utils/test_filesystem.py
@@ -60,7 +60,7 @@ def test_http_package():
 
 @pytest.mark.skip("Skipping because slow, need better test solution")
 def test_ngc_model_file():
-    test_url = "ngc://nvidia/modulus/modulus_dlwp_cubesphere/v0.2"
+    test_url = "ngc://models/nvidia/modulus/modulus_dlwp_cubesphere/v0.2"
     package = filesystem.Package(test_url, seperator="/")
     path = package.get("dlwp_cubesphere.zip")
 
@@ -73,10 +73,10 @@ def test_ngc_model_file():
 
 
 @pytest.mark.skipif(
-    "API_KEY" not in os.environ, reason="Skipping because no NGC API key"
+    "NGC_API_KEY" not in os.environ, reason="Skipping because no NGC API key"
 )
 def test_ngc_model_file_private():
-    test_url = "ngc://nvstaging/simnet/modulus_ci/v0.1"
+    test_url = "ngc://models/nvstaging/simnet/modulus_ci/v0.1"
     package = filesystem.Package(test_url, seperator="/")
     path = package.get("test.txt")
 

--- a/test/utils/test_filesystem.py
+++ b/test/utils/test_filesystem.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import hashlib
+import os
 from pathlib import Path
+
+import pytest
 
 from modulus.utils import filesystem
 
@@ -52,4 +55,30 @@ def test_http_package():
     path = package.get("modulus-pipes.jpg")
 
     known_checksum = "e075b2836d03f7971f754354807dcdca51a7875c8297cb161557946736d1f7fc"
+    assert calculate_checksum(path) == known_checksum
+
+
+@pytest.mark.skip("Skipping because slow, need better test solution")
+def test_ngc_model_file():
+    test_url = "ngc://nvidia/modulus/modulus_dlwp_cubesphere/v0.2"
+    package = filesystem.Package(test_url, seperator="/")
+    path = package.get("dlwp_cubesphere.zip")
+
+    path = Path(path)
+    folders = [f for f in path.iterdir()]
+    assert len(folders) == 1 and folders[0].name == "dlwp"
+
+    files = [f for f in folders[0].iterdir()]
+    assert len(files) == 11
+
+
+@pytest.mark.skipif(
+    "API_KEY" not in os.environ, reason="Skipping because no NGC API key"
+)
+def test_ngc_model_file_private():
+    test_url = "ngc://nvstaging/simnet/modulus_ci/v0.1"
+    package = filesystem.Package(test_url, seperator="/")
+    path = package.get("test.txt")
+
+    known_checksum = "d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26"
     assert calculate_checksum(path) == known_checksum

--- a/test/utils/test_filesystem.py
+++ b/test/utils/test_filesystem.py
@@ -58,9 +58,9 @@ def test_http_package():
     assert calculate_checksum(path) == known_checksum
 
 
-@pytest.mark.skip("Skipping because slow, need better test solution")
+# @pytest.mark.skip("Skipping because slow, need better test solution")
 def test_ngc_model_file():
-    test_url = "ngc://models/nvidia/modulus/modulus_dlwp_cubesphere/v0.2"
+    test_url = "ngc://models/nvidia/modulus/modulus_dlwp_cubesphere@v0.2"
     package = filesystem.Package(test_url, seperator="/")
     path = package.get("dlwp_cubesphere.zip")
 
@@ -76,7 +76,7 @@ def test_ngc_model_file():
     "NGC_API_KEY" not in os.environ, reason="Skipping because no NGC API key"
 )
 def test_ngc_model_file_private():
-    test_url = "ngc://models/nvstaging/simnet/modulus_ci/v0.1"
+    test_url = "ngc://models/nvstaging/simnet/modulus_ci@v0.1"
     package = filesystem.Package(test_url, seperator="/")
     path = package.get("test.txt")
 

--- a/test/utils/test_filesystem.py
+++ b/test/utils/test_filesystem.py
@@ -93,14 +93,6 @@ def test_ngc_model_file_invalid():
     except ValueError:
         pass
 
-    test_url = "ngc://nvidia/modulus/modulus_dlwp_cubesphere@v0.2"
-    package = filesystem.Package(test_url, seperator="/")
-    try:
-        package.get("dlwp_cubesphere.zip")
-        raise Exception("Processed invalid model url")
-    except ValueError:
-        pass
-
     test_url = "ngc://models/nvidia/modulus_dlwp_cubesphere@v0.2"
     package = filesystem.Package(test_url, seperator="/")
     try:

--- a/test/utils/test_filesystem.py
+++ b/test/utils/test_filesystem.py
@@ -58,7 +58,7 @@ def test_http_package():
     assert calculate_checksum(path) == known_checksum
 
 
-# @pytest.mark.skip("Skipping because slow, need better test solution")
+@pytest.mark.skip("Skipping because slow, need better test solution")
 def test_ngc_model_file():
     test_url = "ngc://models/nvidia/modulus/modulus_dlwp_cubesphere@v0.2"
     package = filesystem.Package(test_url, seperator="/")
@@ -82,3 +82,37 @@ def test_ngc_model_file_private():
 
     known_checksum = "d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26"
     assert calculate_checksum(path) == known_checksum
+
+
+def test_ngc_model_file_invalid():
+    test_url = "ngc://models/nvidia/modulus/modulus_dlwp_cubesphere/v0.2"
+    package = filesystem.Package(test_url, seperator="/")
+    try:
+        package.get("dlwp_cubesphere.zip")
+        raise Exception("Processed invalid model url")
+    except ValueError:
+        pass
+
+    test_url = "ngc://nvidia/modulus/modulus_dlwp_cubesphere@v0.2"
+    package = filesystem.Package(test_url, seperator="/")
+    try:
+        package.get("dlwp_cubesphere.zip")
+        raise Exception("Processed invalid model url")
+    except ValueError:
+        pass
+
+    test_url = "ngc://models/nvidia/modulus_dlwp_cubesphere@v0.2"
+    package = filesystem.Package(test_url, seperator="/")
+    try:
+        package.get("dlwp_cubesphere.zip")
+        raise Exception("Processed invalid model url")
+    except ValueError:
+        pass
+
+    test_url = "ngc://models/nvidia/modulus/other/modulus_dlwp_cubesphere@v0.2"
+    package = filesystem.Package(test_url, seperator="/")
+    try:
+        package.get("dlwp_cubesphere.zip")
+        raise Exception("Processed invalid model url")
+    except ValueError:
+        pass

--- a/test/utils/test_filesystem.py
+++ b/test/utils/test_filesystem.py
@@ -87,24 +87,15 @@ def test_ngc_model_file_private():
 def test_ngc_model_file_invalid():
     test_url = "ngc://models/nvidia/modulus/modulus_dlwp_cubesphere/v0.2"
     package = filesystem.Package(test_url, seperator="/")
-    try:
+    with pytest.raises(ValueError):
         package.get("dlwp_cubesphere.zip")
-        raise Exception("Processed invalid model url")
-    except ValueError:
-        pass
 
     test_url = "ngc://models/nvidia/modulus_dlwp_cubesphere@v0.2"
     package = filesystem.Package(test_url, seperator="/")
-    try:
+    with pytest.raises(ValueError):
         package.get("dlwp_cubesphere.zip")
-        raise Exception("Processed invalid model url")
-    except ValueError:
-        pass
 
     test_url = "ngc://models/nvidia/modulus/other/modulus_dlwp_cubesphere@v0.2"
     package = filesystem.Package(test_url, seperator="/")
-    try:
+    with pytest.raises(ValueError):
         package.get("dlwp_cubesphere.zip")
-        raise Exception("Processed invalid model url")
-    except ValueError:
-        pass


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adding NGC model file protocol for filesystem in Modulus. Allows users to fetch / unzip files on NGC model registry both public and private.

Users can now use `ngc://org/team/model/version/file` to fetch files from NGC. Also works with private registries if users have set `API_KEY` to the environment variable. If its a zip file, it will automatically unzip its contents. This can be very useful for shipping resources for examples and such.

Related to: https://github.com/NVIDIA/earth2mip/issues/57

Closes: https://github.com/NVIDIA/modulus/issues/217

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->