### PR TITLE
fix crps to use kernel method for large ensemble sizes in pytest

### DIFF
--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -237,7 +237,7 @@ def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
     y = torch.zeros((1,), device=device, dtype=torch.float32)
 
     # Test pure crps
-    c = crps.crps(x, y)
+    c = crps.crps(x, y, method="histogram")
     true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
     assert torch.allclose(
         c,
@@ -247,7 +247,7 @@ def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
     )
 
     # Test when input is numpy array
-    c = crps.crps(x, y.cpu().numpy())
+    c = crps.crps(x, y.cpu().numpy(), method="histogram")
     assert torch.allclose(
         c,
         true_crps * torch.ones([1], dtype=torch.float32, device=device),
@@ -255,8 +255,8 @@ def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
         atol=atol,
     )
 
-    # Test kernel method, use fewer ensemble members
-    c = crps.kcrps(x[:1000], y)
+    # Test pure crps
+    c = crps.crps(x[:100], y, method="kernel")
     true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
     assert torch.allclose(
         c,
@@ -265,14 +265,23 @@ def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
         atol=50 * atol,
     )
 
-    # Test kernel method
-    c = crps.kcrps(x, y)
+    # Test when input is numpy array
+    c = crps.crps(x[:100], y.cpu().numpy(), method="kernel")
+    assert torch.allclose(
+        c,
+        true_crps * torch.ones([1], dtype=torch.float32, device=device),
+        rtol=50 * rtol,
+        atol=50 * atol,
+    )
+
+    # Test kernel method, use fewer ensemble members
+    c = crps.kcrps(x[:100], y)
     true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
     assert torch.allclose(
         c,
         true_crps * torch.ones([1], dtype=torch.float32, device=device),
-        rtol=rtol,
-        atol=atol,
+        rtol=50 * rtol,
+        atol=50 * atol,
     )
 
     # Test Gaussian CRPS


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Fixes `test/metrics/test_metrics_general.py::test_crps` to use the histogram method for large ensemble sizes instead of the kernel method, which has longer runtimes.

Closes #224 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies
