### PR TITLE
Add git hash to the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,10 @@ COPY . /modulus/
 RUN cd /modulus/ && pip install .
 RUN pip install --no-cache-dir "protobuf==3.20.3"
 
+# Set Git Hash as a environment variable
+ARG MODULUS_GIT_HASH
+ENV MODULUS_GIT_HASH=${MODULUS_GIT_HASH:-unknown}
+
 # Clean up
 RUN rm -rf /modulus/ 
 

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,10 @@ else
     $(error Unknown CPU architecture ${ARCH} detected)
 endif
 
+MODULUS_GIT_HASH = $(shell git rev-parse --short HEAD)
 
 container-deploy:
-	docker build -t modulus:deploy --build-arg TARGETPLATFORM=${TARGETPLATFORM} --target deploy -f Dockerfile .
+	docker build -t modulus:deploy --build-arg TARGETPLATFORM=${TARGETPLATFORM} --build-arg MODULUS_GIT_HASH=${MODULUS_GIT_HASH} --target deploy -f Dockerfile .
 
 container-ci:
 	docker build -t modulus:ci --build-arg TARGETPLATFORM=${TARGETPLATFORM} --target ci -f Dockerfile .


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Adds git hash to the docker container. If the build arg is not provided, it will default to unknown. 

Sample output:

```
docker run --rm --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 --runtime nvidia -v ${PWD}:/workspace -it modulus:deploy /bin/bash -c 'echo $MODULUS_GIT_HASH'
...
<header content>
...
9fc5d8b
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->