### PR TITLE
Fix pydantic issues

### DIFF
--- a/examples/cfd/ahmed_body_mgn/constants.py
+++ b/examples/cfd/ahmed_body_mgn/constants.py
@@ -30,9 +30,9 @@ class Constants(BaseModel):
     input_dim_edges: int = 4
     output_dim: int = 4
     aggregation: int = "sum"
-    hidden_dim_node_encoder = 256
-    hidden_dim_edge_encoder = 256
-    hidden_dim_node_decoder = 256
+    hidden_dim_node_encoder: int = 256
+    hidden_dim_edge_encoder: int = 256
+    hidden_dim_node_decoder: int = 256
 
     batch_size: int = 1
     epochs: int = 500
@@ -46,4 +46,4 @@ class Constants(BaseModel):
     amp: bool = False
     jit: bool = False
 
-    wandb_mode = "disabled"
+    wandb_mode: str = "disabled"

--- a/examples/cfd/stokes_mgn/train.py
+++ b/examples/cfd/stokes_mgn/train.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
         with open(
             os.path.join(C.ckpt_path, C.ckpt_name.replace(".pt", ".json")), "w"
         ) as json_file:
-            json_file.write(C.json(indent=4))
+            json_file.write(C.model_dump_json(indent=4))
 
     # initialize loggers
     initialize_wandb(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Pydantic v2 update requires changes to some apis. The Stokes flow example change is similar to the one done here: https://github.com/NVIDIA/modulus/pull/226. 

Pydantic also requires type annotations (ahmed body example fixes). 

```
pydantic.errors.PydanticUserError: A non-annotated attribute was detected: `hidden_dim_node_encoder = 256`. All model fields require a type annotation; if `hidden_dim_node_encoder` is not meant to be a field, you may be able to resolve this error by annotating it as a `ClassVar` or updating `model_config['ignored_types']`.
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->