### PR TITLE
apply scaling to input but not conditioning data 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Ahmed Body and Vortex Shedding examples to use Hydra config.
 - Added more config options to FCN AFNO example.
+- In `models/diffusion/preconditioning.py` scale on `x`, leave `img_lr` unscaled.
 
 ### Deprecated
 

--- a/modulus/models/diffusion/preconditioning.py
+++ b/modulus/models/diffusion/preconditioning.py
@@ -760,7 +760,7 @@ class EDMPrecondSR(Module):
         x = x.to(torch.float32)
         # Apply scaling to x
         x = (1 / (self.sigma_data**2 + sigma**2).sqrt()) * x
-        
+
         sigma = sigma.to(torch.float32).reshape(-1, 1, 1, 1)
         class_labels = (
             None
@@ -781,7 +781,7 @@ class EDMPrecondSR(Module):
         c_noise = sigma.log() / 4
 
         x = torch.cat((x, img_lr), dim=1)
-        
+
         F_x = self.model(
             (c_in * x).to(dtype),
             c_noise.flatten(),

--- a/modulus/models/diffusion/preconditioning.py
+++ b/modulus/models/diffusion/preconditioning.py
@@ -757,10 +757,10 @@ class EDMPrecondSR(Module):
     def forward(
         self, x, img_lr, sigma, class_labels=None, force_fp32=False, **model_kwargs
     ):
-        # Concatenate input channels
-        x = torch.cat((x, img_lr), dim=1)
-
         x = x.to(torch.float32)
+        # Apply scaling to x
+        x = (1 / (self.sigma_data**2 + sigma**2).sqrt()) * x
+        
         sigma = sigma.to(torch.float32).reshape(-1, 1, 1, 1)
         class_labels = (
             None
@@ -780,6 +780,8 @@ class EDMPrecondSR(Module):
         c_in = 1 / (self.sigma_data**2 + sigma**2).sqrt()
         c_noise = sigma.log() / 4
 
+        x = torch.cat((x, img_lr), dim=1)
+        
         F_x = self.model(
             (c_in * x).to(dtype),
             c_noise.flatten(),


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
This PR closes #229; where the scaling was originally applied to both the input `x` and the low resolution conditioning data `img_lr` and its now applied only to `x`. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.
