### PR TITLE
Fix corr-diff conditional scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `modulus.models.diffusion.preconditioning.EDMPrecondSR`. Use `EDMPecondSRV2` instead.
+
 ### Removed
 
 ### Fixed

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -202,8 +202,11 @@ def main(cfg: DictConfig) -> None:
         )
 
     # Preconditioning & loss function.
-    if precond == "edm":
+    if precond == "edmv2" or precond == "edm":
         c.network_kwargs.class_name = "training.networks.EDMPrecondSRV2"
+        c.loss_kwargs.class_name = "modulus.metrics.diffusion.EDMLossSR"
+    elif precond == "edmv1":
+        c.network_kwargs.class_name = "training.networks.EDMPrecondSR"
         c.loss_kwargs.class_name = "modulus.metrics.diffusion.EDMLossSR"
     elif precond == "unetregression":
         c.network_kwargs.class_name = "modulus.models.diffusion.UNet"

--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -203,7 +203,7 @@ def main(cfg: DictConfig) -> None:
 
     # Preconditioning & loss function.
     if precond == "edm":
-        c.network_kwargs.class_name = "training.networks.EDMPrecondSR"
+        c.network_kwargs.class_name = "training.networks.EDMPrecondSRV2"
         c.loss_kwargs.class_name = "modulus.metrics.diffusion.EDMLossSR"
     elif precond == "unetregression":
         c.network_kwargs.class_name = "modulus.models.diffusion.UNet"

--- a/modulus/models/diffusion/preconditioning.py
+++ b/modulus/models/diffusion/preconditioning.py
@@ -20,6 +20,7 @@ Diffusion-Based Generative Models".
 """
 
 import importlib
+import warnings
 from dataclasses import dataclass
 from typing import List, Union
 
@@ -733,6 +734,13 @@ class EDMPrecondSR(Module):
         model_type="DhariwalUNet",
         **model_kwargs,
     ):
+        warnings.warn(
+            "EDMPrecondSR has a bug in how the conditional input is scaled "
+            "(see https://github.com/NVIDIA/modulus/issues/229). "
+            "This preconditioner is now deprecated. "
+            "Please use EDMPrecondSRV2 instead.",
+            DeprecationWarning,
+        )
         super().__init__(meta=EDMPrecondSRMetaData)
         self.img_resolution = img_resolution
         self.img_channels = img_channels
@@ -806,3 +814,154 @@ class EDMPrecondSR(Module):
         See EDMPrecond.round_sigma
         """
         return EDMPrecond.round_sigma(sigma)
+
+
+class _ConditionalPrecond(torch.nn.Module):
+    """EDM Preconditioner with appropriate handling of conditional inputs via concatenation
+
+    This class is more modular since ``model`` is not constructed here.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        model: torch.nn.Module,
+        img_resolution: int,
+        img_channels: int,
+        label_dim=0,
+        use_fp16=False,
+        sigma_min=0,
+        sigma_max=float("inf"),
+        sigma_data=0.5,
+    ):
+        super().__init__()
+
+        # metadata. Not clear which is of these is used externally. I believe
+        # img_resolution and img_channels are.
+        self.label_dim = label_dim
+        self.use_fp16 = use_fp16
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
+        self.sigma_data = sigma_data
+        self.img_resolution = img_resolution
+        self.img_channels = img_channels
+        self.model = model
+
+    @nvtx.annotate(message="_ConditionalPrecond", color="orange")
+    def forward(
+        self,
+        x,
+        sigma,
+        class_labels=None,
+        condition=None,
+        force_fp32=False,
+        **model_kwargs,
+    ):
+        x = x.to(torch.float32)
+        sigma = sigma.to(torch.float32).reshape(-1, 1, 1, 1)
+        class_labels = (
+            None
+            if self.label_dim == 0
+            else (
+                torch.zeros([1, self.label_dim], device=x.device)
+                if class_labels is None
+                else class_labels.to(torch.float32).reshape(-1, self.label_dim)
+            )
+        )
+        dtype = (
+            torch.float16
+            if (self.use_fp16 and not force_fp32 and x.device.type == "cuda")
+            else torch.float32
+        )
+
+        c_skip = self.sigma_data**2 / (sigma**2 + self.sigma_data**2)
+        c_out = sigma * self.sigma_data / (sigma**2 + self.sigma_data**2).sqrt()
+        c_in = 1 / (self.sigma_data**2 + sigma**2).sqrt()
+        c_noise = sigma.log() / 4
+
+        if condition is None:
+            arg = c_in * x
+        else:
+            condition = condition.to(torch.float32)
+            arg = torch.cat([c_in * x, condition], dim=1)
+
+        F_x = self.model(
+            arg.to(dtype), c_noise.flatten(), class_labels=class_labels, **model_kwargs
+        )
+        D_x = c_skip * x + c_out * F_x.to(torch.float32)
+        return D_x
+
+    def round_sigma(self, sigma):
+        return torch.as_tensor(sigma)
+
+
+def EDMPrecondSRV2(
+    img_resolution,
+    img_in_channels,
+    img_out_channels,
+    label_dim=0,
+    use_fp16=False,
+    sigma_min=0.0,
+    sigma_max=float("inf"),
+    sigma_data=0.5,
+    model_type="DhariwalUNet",
+    **model_kwargs,
+) -> _ConditionalPrecond:
+    """EDM Preconditioner with appropriate handling of conditional inputs via concatenation
+
+    This helper is provided to have a similar interface to EDMPrecondSR,
+    which includes the model construction.
+
+    Parameters
+    ----------
+    img_resolution : int
+        Image resolution.
+    img_in_channels : int
+        Number of input color channels.
+    img_out_channels : int
+        Number of output color channels.
+    label_dim : int
+        Number of class labels, 0 = unconditional, by default 0.
+    use_fp16 : bool
+        Execute the underlying model at FP16 precision?, by default False.
+    sigma_min : float
+        Minimum supported noise level, by default 0.0.
+    sigma_max : float
+        Maximum supported noise level, by default inf.
+    sigma_data : float
+        Expected standard deviation of the training data, by default 0.5.
+    model_type :str
+        Class name of the underlying model, by default "DhariwalUNet".
+    **model_kwargs : dict
+        Keyword arguments for the underlying model.
+
+    Note
+    ----
+    References:
+    - Karras, T., Aittala, M., Aila, T. and Laine, S., 2022. Elucidating the
+    design space of diffusion-based generative models. Advances in Neural Information
+    Processing Systems, 35, pp.26565-26577.
+    - Mardani, M., Brenowitz, N., Cohen, Y., Pathak, J., Chen, C.Y.,
+    Liu, C.C.,Vahdat, A., Kashinath, K., Kautz, J. and Pritchard, M., 2023.
+    Generative Residual Diffusion Modeling for Km-scale Atmospheric Downscaling.
+    arXiv preprint arXiv:2309.15214.
+    """
+    model_class = getattr(network_module, model_type)
+    model = model_class(
+        img_resolution=img_resolution,
+        in_channels=img_in_channels + img_out_channels,
+        out_channels=img_out_channels,
+        label_dim=label_dim,
+        **model_kwargs,
+    )
+    return _ConditionalPrecond(
+        model=model,
+        img_resolution=img_resolution,
+        img_channels=img_out_channels,
+        label_dim=label_dim,
+        use_fp16=use_fp16,
+        sigma_min=sigma_min,
+        sigma_max=sigma_max,
+        sigma_data=sigma_data,
+    )

--- a/test/models/diffusion/test_preconditioning.py
+++ b/test/models/diffusion/test_preconditioning.py
@@ -16,7 +16,11 @@
 
 import torch
 
-from modulus.models.diffusion.preconditioning import EDMPrecondSRV2, _ConditionalPrecond
+from modulus.models.diffusion.preconditioning import (
+    EDMPrecondSRV2,
+    _ConditionalPrecond,
+)
+from modulus.models.module import Module
 
 
 def test__ConditionalPrecond():
@@ -50,6 +54,10 @@ def test__ConditionalPrecond():
     assert torch.allclose(torch.tensor(expected), torch.max(output))
 
 
-def test_EDMPrecondSRV2():
+def test_EDMPrecondSRV2_serialization(tmp_path):
     module = EDMPrecondSRV2(8, 1, 1)
     assert isinstance(module, _ConditionalPrecond)
+    model_path = tmp_path / "output.mdlus"
+    module.save(model_path.as_posix())
+    loaded = Module.from_checkpoint(model_path.as_posix())
+    assert isinstance(loaded, EDMPrecondSRV2)

--- a/test/models/diffusion/test_preconditioning.py
+++ b/test/models/diffusion/test_preconditioning.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from modulus.models.diffusion.preconditioning import EDMPrecondSRV2, _ConditionalPrecond
+
+
+def test__ConditionalPrecond():
+
+    b, c_target, x, y = 1, 3, 8, 8
+    c_cond = 4
+
+    def forward(x, sigma, *, class_labels):
+        assert x.shape[1] == c_target + c_cond
+        # add mean of full array and sigma, so that changing the scaling will
+        # break the regression check
+        return x[:, :c_target] + torch.mean(x, dim=1, keepdim=True) + sigma
+
+    preconditioned_model = _ConditionalPrecond(
+        model=forward, img_channels=c_target, img_resolution=8
+    )
+
+    latents = torch.ones((b, c_target, x, y))
+    image_conditioning = torch.arange(b * c_cond * x * y).reshape((b, c_cond, x, y))
+    sigma = 10.0
+    output = preconditioned_model(
+        latents,
+        condition=image_conditioning,
+        sigma=preconditioned_model.round_sigma(sigma),
+    )
+    assert output.shape == latents.shape
+
+    # this expected value is a regression check...if you have made an
+    # intentional change, feel free to change it
+    expected = 45.7331
+    assert torch.allclose(torch.tensor(expected), torch.max(output))
+
+
+def test_EDMPrecondSRV2():
+    module = EDMPrecondSRV2(8, 1, 1)
+    assert isinstance(module, _ConditionalPrecond)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

This PR fixes the scaling for conditional inputs in corrdiff. Previously the conditional inputs were concatenated with the noisy target BEFORE scaling. This means that for large noise the conditional inputs will also be scaled down to near 0. This is undesirable since the large-noise limits corresponds to deterministic prediction---we expect the conditional inputs to matter most in this case! This PR fixes this by scaling the noise image BEFORE concatenating it with the conditioning.

I wrote this PR with unit testing in mind, so I wrote a modular class `_ConditionalPrecond` which is testable in isolation. I added a public API `EDMPrecondSRV2` to provide a similar interface as `EDMPrecondSR` that also builds the UNet.

Closes #229.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->