### PR TITLE
Adding url meta data to TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+[project.urls]
+Homepage = "https://github.com/NVIDIA/modulus"
+Documentation = "https://docs.nvidia.com/modulus/#core"
+Issues = "https://github.com/NVIDIA/modulus/issues"
+Changelog = "https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md"
+
 [project.optional-dependencies]
 launch = [
     "hydra-core>=1.2.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adding URLs to TOML meta data for python package parsers:

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

Noticed this too many times with the pip license package failing to get a URL for modulus, decided to finally fix that hopefully.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->