### PR TITLE
CorrDiff: Remove extra call to training_loop

### DIFF
--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -333,9 +333,7 @@ def main(cfg: DictConfig) -> None:
 
     # Train.
     training_loop.training_loop(
-        training_loop.training_loop(
-            dataset, dataset_iter, valid_dataset, valid_dataset_iter, **c
-        )
+        dataset, dataset_iter, valid_dataset, valid_dataset_iter, **c
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
When I ran the training example I got the following error at the end:
```
Traceback (most recent call last):
  File "/code/modulus/examples/generative/corrdiff/train.py", line 335, in main
    training_loop.training_loop(
TypeError: training_loop() missing 3 required positional arguments: 'dataset_iterator', 'validation_dataset', and 'validation_dataset_iterator'
```
The problem appears to be that `training_loop` is called twice in a nested fashion. Since the error is only thrown on the outside call after the first call completes, the error is only raised after the training has already completed (which is why this probably wasn't noticed earlier).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->