### PR TITLE
Create .cdsapirc file for CDSAPI automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ nsight-systems*
 build/
 mlruns/
 checkpoints/
+examples/weather/dataset_download/credentials/
 
 # Hydra
 outputs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Automatic .cdsapirc file creation for /examples/weather/dataset_download/
+
 ### Deprecated
 
 ### Removed

--- a/examples/weather/dataset_download/README.md
+++ b/examples/weather/dataset_download/README.md
@@ -15,6 +15,9 @@ flexibly select different meteorological variables for their training dataset.
     surface temperature variable however if you would like a more complete dataset such
     as the one used to train [FourCastNet](https://arxiv.org/abs/2202.11214),
     please use `conf/config_34var.yaml`.
+4. `credentials/cdsapi.yaml` - can be used to enter the credentials for CDS API when
+    using a container environment. Should never be commited because it contains
+    sensitive information.
 
 ## How to Use
 

--- a/examples/weather/dataset_download/credentials/cdsapi.yaml
+++ b/examples/weather/dataset_download/credentials/cdsapi.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url:
+key:


### PR DESCRIPTION
…credentials provided in the project folder. This will be useful when we don#t want to save the credentials in the container permanently

<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
When downloading the ERA5 data with /examples/weather/dataset_download/ it is required that a .cdsapirc file is located in the home directory. 

The proposed changes in this merge request provide a backup solution for the creation of this file if it is not available (e.g. when using a docker container) or we don't want to save these credentials permanently in a docker container. 

In that case the credentials can be specified in ./credentials/cdsapi.yaml and will be used to create the corresponding .cdsapirc automatically at runtime when needed.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies
None

<!-- Call out any new dependencies needed if any -->