### PR TITLE
Add Sorted Empirical CDF CRPS algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Diffusion model for fluid data super-resolution (CMU contribution).
 - The Virtual Foundry GraphNet.
 - A synthetic dataloader for global weather prediction models, demonstrated on GraphCast.
+- Sorted Empirical CDF CRPS algorithm
 
 ### Changed
 

--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -281,6 +281,46 @@ def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
         atol=100 * atol,
     )
 
+    # Test sorted crps
+    c = crps.crps(x[:10_000], y, method="sort")
+    true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
+    assert torch.allclose(
+        c,
+        true_crps * torch.ones([1], dtype=torch.float32, device=device),
+        rtol=10 * rtol,
+        atol=10 * atol,
+    )
+
+    # Test when input is numpy array
+    c = crps.crps(x[:10_000], y.cpu().numpy(), method="sort")
+    assert torch.allclose(
+        c,
+        true_crps * torch.ones([1], dtype=torch.float32, device=device),
+        rtol=10 * rtol,
+        atol=10 * atol,
+    )
+
+    # test sort method
+    c = crps._crps_from_empirical_cdf(x[:10_000], y)
+    true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
+    assert torch.allclose(
+        c,
+        true_crps * torch.ones([1], dtype=torch.float32, device=device),
+        rtol=10 * rtol,
+        atol=10 * atol,
+    )
+
+    c = crps._crps_from_empirical_cdf(
+        torch.randn((1, 10_000), device=device, dtype=torch.float32), y, dim=1
+    )
+    true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
+    assert torch.allclose(
+        c,
+        true_crps * torch.ones([1], dtype=torch.float32, device=device),
+        rtol=10 * rtol,
+        atol=10 * atol,
+    )
+
     # Test Gaussian CRPS
     mm = torch.zeros([1], dtype=torch.float32, device=device)
     vv = torch.ones([1], dtype=torch.float32, device=device)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
This PR adds another method for computing the Continuous Ranked Probability Score. It lifts the implementation from Earth2MIP, https://github.com/NVIDIA/earth2mip/blob/main/earth2mip/crps.py, at the request from @nbren12.

Closes #455 
## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.
