### PR TITLE
Update logic on corrdiff patch based training

### DIFF
--- a/examples/generative/corrdiff/train.py
+++ b/examples/generative/corrdiff/train.py
@@ -330,11 +330,11 @@ def main(cfg: DictConfig) -> None:
         c.patch_shape_x = img_shape_x
     if (c.patch_shape_y is None) or (c.patch_shape_y > img_shape_y):
         c.patch_shape_y = img_shape_y
-    if c.patch_shape_x != c.patch_shape_y:
-        raise NotImplementedError("Rectangular patch not supported yet")
-    if c.patch_shape_x % 32 != 0 or c.patch_shape_y % 32 != 0:
-        raise ValueError("Patch shape needs to be a multiple of 32")
     if c.patch_shape_x != img_shape_x or c.patch_shape_y != img_shape_y:
+        if c.patch_shape_x != c.patch_shape_y:
+            raise NotImplementedError("Rectangular patch not supported yet")
+        if c.patch_shape_x % 32 != 0 or c.patch_shape_y % 32 != 0:
+            raise ValueError("Patch shape needs to be a multiple of 32")
         logger0.info("Patch-based training enabled")
     else:
         logger0.info("Patch-based training disabled")


### PR DESCRIPTION
The existing patch based training check automatically assumes that the patch size is not the full region. If a full domain region that is rectangular is being trained It is incorrectly rejected as being patch based.

<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Updates the logic on the patch based size checking to avoid incorrectly rejecting full domain trainings.
Fixes issue: 
https://github.com/NVIDIA/modulus/issues/522

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies