### PR TITLE
Misc fixes: Stokes dataset connectivity, distributed manager initialization and error messages

### DIFF
--- a/modulus/datapipes/gnn/stokes_dataset.py
+++ b/modulus/datapipes/gnn/stokes_dataset.py
@@ -286,12 +286,14 @@ class StokesDataset(DGLDataset):
         polys = polydata.GetPolys()
         polys.InitTraversal()
         edge_list = []
-        for i in range(polys.GetNumberOfCells()):
-            id_list = vtk.vtkIdList()
+        id_list = vtk.vtkIdList()
+
+        for _ in range(polys.GetNumberOfCells()):
             polys.GetNextCell(id_list)
-            for j in range(id_list.GetNumberOfIds() - 1):
+            num_ids = id_list.GetNumberOfIds()
+            for j in range(num_ids):
                 edge_list.append(  # noqa: PERF401
-                    (id_list.GetId(j), id_list.GetId(j + 1))
+                    (id_list.GetId(j), id_list.GetId((j + 1) % num_ids))
                 )
 
         # Create DGL graph using the connectivity information

--- a/modulus/distributed/manager.py
+++ b/modulus/distributed/manager.py
@@ -48,11 +48,13 @@ class ModulusUninitializedDistributedManagerWarning(Warning):
     """Warning to indicate usage of an uninitialized DistributedManager"""
 
     def __init__(self):
-        message = "A DistributedManager object is being instantiated before "
-        "this singleton class has been initialized. Instantiating a manager before "
-        "initialization can lead to unexpected results where processes fail "
-        "to communicate. Initialize the distributed manager via "
-        "DistributedManager.initialize() before instantiating."
+        message = (
+            "A DistributedManager object is being instantiated before "
+            + "this singleton class has been initialized. Instantiating a manager before "
+            + "initialization can lead to unexpected results where processes fail "
+            + "to communicate. Initialize the distributed manager via "
+            + "DistributedManager.initialize() before instantiating."
+        )
         super().__init__(message)
 
 

--- a/modulus/launch/utils/checkpoint.py
+++ b/modulus/launch/utils/checkpoint.py
@@ -74,6 +74,7 @@ def _get_checkpoint_filename(
     # can save their checkpoint. In the case without model parallelism,
     # model_parallel_rank should be the same as the process rank itself and
     # only rank 0 saves
+    DistributedManager.initialize()
     manager = DistributedManager()
     model_parallel_rank = (
         manager.group_rank("model_parallel")

--- a/modulus/launch/utils/checkpoint.py
+++ b/modulus/launch/utils/checkpoint.py
@@ -74,7 +74,11 @@ def _get_checkpoint_filename(
     # can save their checkpoint. In the case without model parallelism,
     # model_parallel_rank should be the same as the process rank itself and
     # only rank 0 saves
-    DistributedManager.initialize()
+    if not DistributedManager.is_initialized():
+        checkpoint_logging.warning(
+            "`DistributedManager` not initialized already. Initializing now, but this might lead to unexpected errors"
+        )
+        DistributedManager.initialize()
     manager = DistributedManager()
     model_parallel_rank = (
         manager.group_rank("model_parallel")


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
This PR fixes a few following issues: 
1. Stokes dataset was not capturing all the edges of a graph. 
2. The error message printed by uninitialized distributed manager was incomplete. 
3. Distributed manager was uninitialized in the load checkpoint utility. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->