### PR TITLE
Fix bug which misses an edge during graph creation

### DIFF
--- a/modulus/datapipes/gnn/ahmed_body_dataset.py
+++ b/modulus/datapipes/gnn/ahmed_body_dataset.py
@@ -604,6 +604,12 @@ class AhmedBodyDataset(DGLDataset, Datapipe):
                     (id_list.GetId(j), id_list.GetId(j + 1))
                 )
 
+            # Add the final edge between last and first vertex
+            edge_list.append(
+                    (id_list.GetId(id_list.GetNumberOfIds() - 1), id_list.GetId(0))
+            )
+
+
         # Create DGL graph using the connectivity information
         graph = dgl.graph(edge_list, idtype=dtype)
         if to_bidirected:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
VTK polygon cells 0-1-2-3-0 have four edges. This PR fixes the last missing edge in the cell during graph creation.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->