### PR TITLE
fix CorrDiff: loss is scaled by batch_size_gpu

### DIFF
--- a/examples/generative/corrdiff/training/training_loop.py
+++ b/examples/generative/corrdiff/training/training_loop.py
@@ -277,7 +277,7 @@ def training_loop(
                         augment_pipe=augment_pipe,
                     )
                 training_stats.report("Loss/loss", loss)
-                loss = loss.sum().mul(loss_scaling / batch_gpu_total)
+                loss = loss.sum().mul(loss_scaling / batch_gpu_total / batch_size_gpu)
                 loss_accum += loss / num_accumulation_rounds
                 loss.backward()
 
@@ -331,7 +331,7 @@ def training_loop(
                         )
                         training_stats.report("Loss/validation loss", loss_valid)
                         loss_valid = loss_valid.sum().mul(
-                            loss_scaling / batch_gpu_total
+                            loss_scaling / batch_gpu_total / batch_size_gpu
                         )
                         valid_loss_accum += loss_valid / num_validation_evals
                     valid_loss_sum = torch.tensor([valid_loss_accum], device=device)


### PR DESCRIPTION
CorrDiff training loss is scaled by batch_size_gpu

<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->