### PR TITLE
CRPS improvements: fast and unbiased kernel implementations

### DIFF
--- a/modulus/metrics/general/crps.py
+++ b/modulus/metrics/general/crps.py
@@ -25,6 +25,26 @@ Tensor = torch.Tensor
 
 
 @torch.jit.script
+def _kernel_crps_implementation(pred: Tensor, obs: Tensor, unbiased: bool) -> Tensor:
+    """An O(m log m) implementation of the kernel CRPS formulas"""
+    skill = torch.abs(pred - obs[..., None]).mean(-1)
+    pred, _ = torch.sort(pred)
+
+    # derivation of fast implementation of spread-portion of CRPS formula when x is sorted
+    # sum_(i,j=1)^m |x_i - x_j| = sum_(i<j) |x_i -x_j| + sum_(i > j) |x_i - x_j|
+    #                           = 2 sum_(i <= j) |x_i -x_j|
+    #                           = 2 sum_(i <= j) (x_j - x_i)
+    #                           = 2 sum_(i <= j) x_j - 2 sum_(i <= j) x_i
+    #                           = 2 sum_(j=1)^m j x_j - 2 sum (m - i + 1) x_i
+    #                           = 2 sum_(i=1)^m (2i - m - 1) x_i
+    m = pred.size(-1)
+    i = torch.arange(1, m + 1, device=pred.device, dtype=pred.dtype)
+    denom = m * (m - 1) if unbiased else m * m
+    factor = (2 * i - m - 1) / denom
+    spread = torch.sum(factor * pred, dim=-1)
+    return skill - spread
+
+
 def kcrps(pred: Tensor, obs: Tensor, dim: int = 0):
     """
     Computes the local Continuous Ranked Probability Score (CRPS) by using
@@ -55,23 +75,41 @@ def kcrps(pred: Tensor, obs: Tensor, dim: int = 0):
     Tensor
         Map of CRPS
     """
-    n = pred.shape[dim]
-    device = pred.device
-    _crps = 0.0 * obs
-    for i in range(n):
-        x_i = torch.index_select(
-            pred, dim, torch.tensor([i], device=device, dtype=torch.int32)
-        )
+    pred = pred.transpose(dim, -1)
+    return _kernel_crps_implementation(pred, obs, unbiased=False)
 
-        x_j = torch.index_select(
-            pred,
-            dim,
-            torch.tensor([j for j in range(i, n)], device=device, dtype=torch.int32),
-        )
 
-        _crps += torch.abs(x_i.squeeze(dim) - obs) / n
-        _crps -= torch.sum(torch.abs(x_i - x_j) / n, dim=dim) / n
-    return _crps
+def fair_crps(pred: Tensor, obs: Union[Tensor, np.ndarray], dim: int = 0) -> Tensor:
+    """Estimate the CRPS from a finite ensemble
+
+        E|X-y|/m - 1/(2m(m-1)) sum_(i,j=1)|x_i - x_j|
+
+    Uses the unbiased estimators described in (Zamo and Naveau, 2018). Unlike
+    ``crps`` this is fair for finite ensembles. Non-fair ``crps`` favors less
+    dispersive ensembles since it is biased high by E|X- X'|/ m where m is the
+    ensemble size.
+
+    Cost: O(m log m) in memory and compute
+
+    Args:
+        pred: (..., m) predictions with ensemble along final dimension
+        obs: (..., ) observations. sharing first dimensions of pred
+
+    Returns
+    -------
+    Tensor
+        Map of CRPS
+
+
+    Notes
+    -----
+    Zamo, M., & Naveau, P. (2018). Estimation of the Continuous Ranked
+    Probability Score with Limited Information and Applications to Ensemble
+    Weather Forecasts. Mathematical Geosciences, 50(2), 209–234.
+    https://doi.org/10.1007/s11004-017-9709-7
+    """
+    pred = pred.transpose(dim, -1)
+    return _kernel_crps_implementation(pred, obs, unbiased=True)
 
 
 def _crps_gaussian(mean: Tensor, std: Tensor, obs: Union[Tensor, np.ndarray]) -> Tensor:
@@ -135,83 +173,6 @@ def _crps_gaussian(mean: Tensor, std: Tensor, obs: Union[Tensor, np.ndarray]) ->
     Phi = torch.erf(d / torch.sqrt(torch.as_tensor(2.0)))
 
     return std * (2 * phi + d * Phi - 1.0 / torch.sqrt(torch.as_tensor(torch.pi)))
-
-
-@torch.jit.script
-def _crps_from_empirical_cdf(
-    pred: torch.Tensor, obs: torch.Tensor, dim: int = 0
-) -> torch.Tensor:
-    """Compute the exact CRPS using the CDF method
-
-    Uses this formula
-    .. math::
-        \\int [F(x) - 1(x-y)]^2 dx
-
-    where F is the emperical CDF and 1(x-y) = 1 if x > y.
-
-    This method is more memory efficient than the kernel method, and uses O(n
-    log n) compute instead of O(n^2), where n is the number of ensemble members.
-
-    Parameters
-    ----------
-    pred : torch.Tensor
-        tensor of ensemble members / predictions
-    obs : torch.Tensor
-        tensor of observations
-    dim : int
-        Dimension to perform CRPS reduction over.
-
-    Returns
-    -------
-        tensor of CRPS scores
-
-    """
-    n = pred.shape[dim]
-    device = pred.device
-    pred, _ = torch.sort(pred, dim=dim)
-    ans = torch.zeros_like(obs)
-
-    # dx [F(x) - H(x-y)]^2 = dx [0 - 1]^2 = dx
-    # val = ensemble[0] - truth
-    val = (
-        torch.index_select(
-            pred, dim, torch.tensor([0], device=device, dtype=torch.int32)
-        ).squeeze(dim)
-        - obs
-    )
-    ans += torch.where(val > 0, val, 0.0)
-
-    for i in range(n - 1):
-        x0 = torch.index_select(
-            pred, dim, torch.tensor([i], device=device, dtype=torch.int32)
-        ).squeeze(dim)
-        x1 = torch.index_select(
-            pred, dim, torch.tensor([i + 1], device=device, dtype=torch.int32)
-        ).squeeze(dim)
-
-        cdf = (i + 1) / n
-
-        # a. case y < x0
-        val = (x1 - x0) * (cdf - 1) ** 2
-        mask = obs < x0
-        ans += torch.where(mask, val, 0.0)
-
-        # b. case x0 <= y <= x1
-        val = (obs - x0) * cdf**2 + (x1 - obs) * (cdf - 1) ** 2
-        mask = (obs >= x0) & (obs <= x1)
-        ans += torch.where(mask, val, 0.0)
-
-        # c. case x1 < t
-        mask = obs > x1
-        val = (x1 - x0) * cdf**2
-        ans += torch.where(mask, val, 0.0)
-
-    # dx [F(x) - H(x-y)]^2 = dx [1 - 0]^2 = dx
-    val = obs - torch.index_select(
-        pred, dim, torch.tensor([n - 1], device=device, dtype=torch.int32)
-    ).squeeze(dim)
-    ans += torch.where(val > 0, val, 0.0)
-    return ans
 
 
 def _crps_from_cdf(
@@ -401,68 +362,11 @@ def crps(
 
     n = pred.shape[dim]
     obs = torch.as_tensor(obs, device=pred.device, dtype=pred.dtype)
-    if method == "kernel":
+    if method in ["kernel", "sort"]:
         return kcrps(pred, obs, dim=dim)
-    elif method == "sort":
-        return _crps_from_empirical_cdf(pred, obs, dim=dim)
     else:
         pred = pred.unsqueeze(0).transpose(0, dim + 1).squeeze(dim + 1)
         number_of_bins = max(int(np.sqrt(n)), 100)
         bin_edges, cdf = cdf_function(pred, bins=number_of_bins)
         _crps = _crps_from_cdf(bin_edges, cdf, obs)
         return _crps
-
-
-def fair_crps(pred: Tensor, obs: Union[Tensor, np.ndarray], dim: int = 0) -> Tensor:
-    """Estimate the CRPS from a finite ensemble
-
-        E|X-y|/m - 1/(2m(m-1)) sum_(i,j=1)|x_i - x_j|
-
-    Uses the unbiased estimators described in (Zamo and Naveau, 2018). Unlike
-    ``crps`` this is fair for finite ensembles. Non-fair ``crps`` favors less
-    dispersive ensembles since it is biased high by E|X- X'|/ m where m is the
-    ensemble size.
-
-    Cost: O(m log m) in memory and compute
-
-    Args:
-        pred: (..., m) predictions with ensemble along final dimension
-        obs: (..., ) observations. sharing first dimensions of pred
-
-    Returns
-    -------
-    Tensor
-        Map of CRPS
-
-
-    Notes
-    -----
-    Zamo, M., & Naveau, P. (2018). Estimation of the Continuous Ranked
-    Probability Score with Limited Information and Applications to Ensemble
-    Weather Forecasts. Mathematical Geosciences, 50(2), 209–234.
-    https://doi.org/10.1007/s11004-017-9709-7
-    """
-    pred = pred.transpose(dim, -1)
-    return _fair_crps_implementation(pred, obs, unbiased=True)
-
-
-def _fair_crps_implementation(
-    pred: Tensor, obs: Union[Tensor, np.ndarray], unbiased: bool
-) -> Tensor:
-    skill = torch.abs(pred - obs[..., None]).mean(-1)
-    pred, _ = torch.sort(pred)
-
-    # unbiased formulation of spread:
-    #   1 / (2m * (m-1)) sum_(i,j=1)^m |x_i - x_j|
-    # derivation of fast implementation of spread-portion of CRPS formula when x is sorted
-    # sum_(i,j=1)^m |x_i - x_j| = sum_(i<j) |x_i -x_j| + sum_(i > j) |x_i - x_j|
-    #                           = 2 sum_(i <= j) |x_i -x_j|
-    #                           = 2 sum_(i <= j) (x_j - x_i)
-    #                           = 2 sum_(i <= j) x_j - 2 sum_(i <= j) x_i
-    #                           = 2 sum_(j=1)^m j x_j - 2 sum (m - i + 1) x_i
-    #                           = 2 sum_(i=1)^m (2i - m - 1) x_i
-    m = pred.size(-1)
-    i = torch.arange(1, m + 1, device=pred.device, dtype=pred.dtype)
-    denom = m * (m - 1) if unbiased else m ** 2
-    spread = torch.sum(((2 * i - m - 1) / denom) * pred, dim=-1)
-    return skill - spread

--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -287,6 +287,71 @@ def test_fair_crps_dim_arg_works(device):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("num", [10, 23, 59])
+@pytest.mark.parametrize("biased", [True, False])
+def test_crps_finite(device, num, biased):
+
+    # Test biased and unbiased on uniform data with analytic result
+    pred = torch.linspace(0, 1, num + 1).unsqueeze(-1).to(device)
+    obs = torch.zeros([1], device=device)
+
+    analytic = (2 * num + 1) / (6 * num + 6) if biased else (num - 1) / (3 * num)
+    analytic = torch.as_tensor([analytic], device=device)
+
+    assert torch.all(torch.isclose(analytic, crps.kcrps(pred, obs, biased=biased)))
+
+    # Test biased on random data
+    pred = torch.as_tensor(
+        [
+            -1.9293,
+            0.6454,
+            -0.3902,
+            -1.0438,
+            -1.3573,
+            -0.2942,
+            2.6269,
+            1.0405,
+            -0.5659,
+            -0.1438,
+            -0.3993,
+            0.7306,
+            -0.8229,
+            -0.8500,
+            -0.5732,
+            0.6746,
+            0.7208,
+            0.6172,
+            -1.6648,
+            0.5183,
+            -0.4850,
+            0.3033,
+            2.4232,
+            0.4714,
+            -0.6040,
+            -0.4617,
+            1.3324,
+            -0.7937,
+            0.8862,
+            -1.2291,
+            2.7559,
+            -1.0750,
+            -0.3882,
+            0.2331,
+            0.4886,
+            -0.3715,
+            -0.3438,
+            -0.4229,
+            0.7913,
+            1.0469,
+        ],
+        device=device,
+    ).reshape([-1, 1])
+    obs = torch.as_tensor([-1.1569], device=device)
+    analytic = torch.as_tensor([0.7027], device=device)
+    assert torch.all(torch.isclose(analytic, crps.kcrps(pred, obs, biased=True)))
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
     # Uses eq (5) from Gneiting et al. https://doi.org/10.1175/MWR2904.1
     # crps(N(0, 1), 0.0) = 2 / sqrt(2*pi) - 1/sqrt(pi) ~= 0.23...

--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -275,13 +275,15 @@ def test_fair_crps_converges_to_crps(device):
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_fair_crps_dim_arg_works(device):
-    pred = torch.randn((10, 100), device=device)
+    pred = torch.randn((5, 10, 100), device=device)
 
-    value = fair_crps(pred, torch.zeros([pred.size(0)], device=device), dim=1)
-    assert value.shape == (10,)
+    a, b, c = pred.shape
 
-    value = fair_crps(pred, torch.zeros([pred.size(1)], device=device), dim=0)
-    assert value.shape == (100,)
+    value = fair_crps(pred, torch.zeros([a, c], device=device), dim=1)
+    assert value.shape == (a, c)
+
+    value = fair_crps(pred, torch.zeros([b, c], device=device), dim=0)
+    assert value.shape == (b, c)
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])

--- a/test/metrics/test_metrics_general.py
+++ b/test/metrics/test_metrics_general.py
@@ -354,27 +354,6 @@ def test_crps(device, rtol: float = 1e-3, atol: float = 1e-3):
         atol=10 * atol,
     )
 
-    # test sort method
-    c = crps._crps_from_empirical_cdf(x[:10_000], y)
-    true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
-    assert torch.allclose(
-        c,
-        true_crps * torch.ones([1], dtype=torch.float32, device=device),
-        rtol=10 * rtol,
-        atol=10 * atol,
-    )
-
-    c = crps._crps_from_empirical_cdf(
-        torch.randn((1, 10_000), device=device, dtype=torch.float32), y, dim=1
-    )
-    true_crps = (np.sqrt(2) - 1.0) / np.sqrt(np.pi)
-    assert torch.allclose(
-        c,
-        true_crps * torch.ones([1], dtype=torch.float32, device=device),
-        rtol=10 * rtol,
-        atol=10 * atol,
-    )
-
     # Test Gaussian CRPS
     mm = torch.zeros([1], dtype=torch.float32, device=device)
     vv = torch.ones([1], dtype=torch.float32, device=device)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

Implements the unbiased (fair) versions of the CRPS formula.

This also harmonizes the CRPS implementations. Following Zamo and Naveau, the "kernel" and "sort" methods give identical answers. Also, there is a fast sort-based algorithm for the kernel formula (see the derivation in `_kernel_crps_implementation`). This is also used [by weather bench](https://github.com/google-research/weatherbench2/blob/main/weatherbench2/metrics.py#L715).

I could leave the existing `kcrps` and `_crps_from_empirical_crps` formulas, but seems worthwhile to harmonize the implementations.

Zamo, M., & Naveau, P. (2018). Estimation of the Continuous Ranked Probability Score with Limited Information and Applications to Ensemble Weather Forecasts. Mathematical Geosciences, 50(2), 209–234. https://doi.org/10.1007/s11004-017-9709-7

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->