### PR TITLE
Fix Hydra log management for PythonLogger

### DIFF
--- a/modulus/launch/logging/console.py
+++ b/modulus/launch/logging/console.py
@@ -27,18 +27,6 @@ class PythonLogger:
 
     def __init__(self, name: str = "launch"):
         self.logger = logging.getLogger(name)
-        self.logger.handlers.clear()
-        formatter = logging.Formatter(
-            "[%(asctime)s - %(name)s - %(levelname)s] %(message)s", datefmt="%H:%M:%S"
-        )
-        streamhandler = logging.StreamHandler()
-        streamhandler.setFormatter(formatter)
-        streamhandler.setLevel(logging.INFO)
-        self.logger.addHandler(streamhandler)
-
-        # Not sure if this works
-        self.logger.setLevel(logging.DEBUG)
-        self.logger.propagate = False  # Prevent parent logging
 
     def file_logging(self, file_name: str = "launch.log"):
         """Log to file"""


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Hydra has several capabilities for logging management, including log capturing which are extremely useful for recording training logs.
The `PythonLogger` -- and by extension `LaunchLogger` -- does not work with this, as it resets any handlers set by hydra to set the loggin configuration. As a result, hydra's logging management has no effect the captured logs are empty for a majority of modulus examples that use both hydra & LaunchLogger extensively.

This PR removes the handler overrides, as currently they do not seem to be adding any other functionality.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies
None
<!-- Call out any new dependencies needed if any -->