### PR TITLE
[FEA]: SDF to STL utility using Marching Cubes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Graph Transformer processor for GraphCast/GenCast.
+- Utility to generate STL from Signed Distance Field.
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,9 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] && [ -e "/modulus/deps/torch_cluste
     fi
 RUN pip install --no-cache-dir "torch_geometric==2.5.3"
 
+# Install scikit-image
+RUN pip install --no-cache-dir "scikit-image>=0.24.0"
+
 # cleanup of stage
 RUN rm -rf /modulus/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:24.03-py3
+ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:24.06-py3
 FROM ${BASE_CONTAINER} as builder
 
 ARG TARGETPLATFORM
@@ -125,6 +125,12 @@ FROM builder as ci
 
 ARG TARGETPLATFORM
 
+# TODO: Remove hacky downgrade of netCDF4 package. netCDF4 v1.7.1 has following 
+# issue: https://github.com/Unidata/netcdf4-python/issues/1343
+# This workaround is only added for the CI systems which run pytest only once. 
+# For more details, refer: https://github.com/NVIDIA/modulus/issues/608
+RUN pip install --no-cache-dir "netcdf4>=1.6.3,<1.7.1"
+
 RUN pip install --no-cache-dir "mlflow>=2.1.1"
 
 COPY . /modulus/
@@ -156,8 +162,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] && [ -e "/modulus/deps/torch_cluste
     fi
 RUN pip install --no-cache-dir "torch_geometric==2.5.3"
 
-# Install scikit-image
-RUN pip install --no-cache-dir "scikit-image>=0.24.0"
+# Install scikit-image and stl
+RUN pip install --no-cache-dir "numpy-stl" "scikit-image>=0.24.0"
+
+# Install sparse-dot-mkl
+RUN pip install --no-cache-dir "sparse-dot-mkl"
 
 # cleanup of stage
 RUN rm -rf /modulus/

--- a/modulus/__init__.py
+++ b/modulus/__init__.py
@@ -19,4 +19,4 @@ from .datapipes.meta import DatapipeMetaData
 from .models.meta import ModelMetaData
 from .models.module import Module
 
-__version__ = "0.7.0"
+__version__ = "0.8.0a0"

--- a/modulus/utils/mesh/__init__.py
+++ b/modulus/utils/mesh/__init__.py
@@ -16,3 +16,4 @@
 
 from .combine_vtp_files import combine_vtp_files
 from .convert_file_formats import convert_tesselated_files_in_directory
+from .generate_stl import sdf_to_stl

--- a/modulus/utils/mesh/generate_stl.py
+++ b/modulus/utils/mesh/generate_stl.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: F401
+
+import numpy as np
+import warp as wp
+from numpy.typing import NDArray
+from stl import mesh
+
+
+def sdf_to_stl(
+    field: NDArray[float],
+    threshold: float = 0.0,
+    backend: str = "warp",
+    filename: str = "output_stl.stl",
+):
+    """
+    Helper utility to create STL from input SDF using Marching Cube algorithm.
+    Wrapper around Warp's algorithm: https://nvidia.github.io/warp/modules/runtime.html#marching-cubes
+    and scikit-image's algorithm: https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes
+
+    Parameters
+    ----------
+    field : NDArray[float]
+        SDF field array. Must be a 3D tensor of shape [nx, ny, nz].
+    threshold : float, optional
+        Target iso-surface value, by default 0.0
+    backend : str, optional
+        Backed to use. Options available warp and skimage, by default warp
+    filename : str, optional
+        Filename for output stl file, by default "output_stl.stl"
+    """
+    if backend == "warp":
+        # Convert numpy array to warp array
+        field = wp.array(field)
+
+        mc = wp.MarchingCubes(
+            field.shape[0],
+            field.shape[1],
+            field.shape[2],
+            max_verts=int(1e6),
+            max_tris=int(1e6),
+        )
+
+        # extract the surface
+        mc.surface(field=field, threshold=threshold)
+
+        # extract the vertices and faces
+        verts = mc.verts.numpy()
+        faces = mc.indices.numpy().reshape(-1, 3)
+
+    elif backend == "skimage":
+        try:
+            import skimage  # noqa: F401 for docs
+            from skimage import measure
+        except ImportError:
+            raise ImportError("Install `scikit-image` to use `skimage` backend.")
+
+        verts, faces, _, _ = measure.marching_cubes(
+            field, threshold, spacing=[field.shape[0], field.shape[1], field.shape[2]]
+        )
+
+    # save stl file
+    mesh_data = np.zeros(faces.shape[0], dtype=mesh.Mesh.dtype)
+
+    for i, f in enumerate(faces):
+        for j in range(3):
+            mesh_data["vectors"][i][j] = verts[f[j], :]
+
+    surface_mesh = mesh.Mesh(mesh_data)
+    surface_mesh.save(filename)

--- a/modulus/utils/sdf.py
+++ b/modulus/utils/sdf.py
@@ -99,7 +99,7 @@ def signed_distance_field(
     >>> mesh_indices = np.array((0, 1, 2))
     >>> input_points = [(0.5, 0.5, 0.5)]
     >>> signed_distance_field(mesh_vertices, mesh_indices, input_points).numpy()
-    Module modulus.utils.sdf load on device 'cuda:0' took ...
+    Module ...
     array([0.5], dtype=float32)
     """
 

--- a/modulus/utils/sdf.py
+++ b/modulus/utils/sdf.py
@@ -19,6 +19,7 @@
 import numpy as np
 import warp as wp
 from numpy.typing import NDArray
+from stl import mesh
 
 
 @wp.kernel
@@ -127,3 +128,52 @@ def signed_distance_field(
         return (sdf, sdf_hit_point_id)
     else:
         return sdf
+
+
+def sdf_to_stl(
+    field: NDArray[float],
+    threshold: float = 0.0,
+    max_verts: int = int(1e6),
+    max_tris: int = int(1e6),
+    filename: str = "output_stl.stl",
+):
+    """
+    Helper utility to create STL from input SDF using Marching Cube algorithm.
+    Wrapper around Warp's marching cubes implementation: https://nvidia.github.io/warp/modules/runtime.html#marching-cubes
+
+    Parameters
+    ----------
+    field : NDArray[float]
+        SDF field array. Must be a 3D tensor of shape [nx, ny, nz].
+    threshold : float, optional
+        Target iso-surface value, by default 0.0
+    max_verts : int, optional
+        Maximum expected numper of vertices, by default int(1e6)
+    max_tris : int, optional
+        Maximum expected number of triangles, by default int(1e6)
+    filename : str, optional
+        Filename for output stl file, by default "output_stl.stl"
+    """
+    # Convert numpy array to warp array
+    field = wp.array(field)
+
+    mc = wp.MarchingCubes(
+        field.shape[0], field.shape[1], field.shape[2], max_verts, max_tris
+    )
+
+    # extract the surface
+    mc.surface(field=field, threshold=threshold)
+
+    # extract the vertices and faces
+    verts = mc.verts.numpy()
+    faces = mc.indices.numpy().reshape(-1, 3)
+
+    # save stl file
+    mesh_data = np.zeros(faces.shape[0], dtype=mesh.Mesh.dtype)
+
+    for i, f in enumerate(faces):
+        for j in range(3):
+            mesh_data["vectors"][i][j] = verts[f[j], :]
+
+    surface_mesh = mesh.Mesh(mesh_data)
+    surface_mesh.save(filename)

--- a/modulus/utils/sdf.py
+++ b/modulus/utils/sdf.py
@@ -19,7 +19,6 @@
 import numpy as np
 import warp as wp
 from numpy.typing import NDArray
-from stl import mesh
 
 
 @wp.kernel
@@ -128,66 +127,3 @@ def signed_distance_field(
         return (sdf, sdf_hit_point_id)
     else:
         return sdf
-
-
-def sdf_to_stl(
-    field: NDArray[float],
-    threshold: float = 0.0,
-    backend: str = "warp",
-    filename: str = "output_stl.stl",
-):
-    """
-    Helper utility to create STL from input SDF using Marching Cube algorithm.
-    Wrapper around Warp's algorithm: https://nvidia.github.io/warp/modules/runtime.html#marching-cubes
-    and scikit-image's algorithm: https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes
-
-    Parameters
-    ----------
-    field : NDArray[float]
-        SDF field array. Must be a 3D tensor of shape [nx, ny, nz].
-    threshold : float, optional
-        Target iso-surface value, by default 0.0
-    backend : str, optional
-        Backed to use. Options available warp and skimage, by default warp
-    filename : str, optional
-        Filename for output stl file, by default "output_stl.stl"
-    """
-    if backend == "warp":
-        # Convert numpy array to warp array
-        field = wp.array(field)
-
-        mc = wp.MarchingCubes(
-            field.shape[0],
-            field.shape[1],
-            field.shape[2],
-            max_verts=int(1e6),
-            max_tris=int(1e6),
-        )
-
-        # extract the surface
-        mc.surface(field=field, threshold=threshold)
-
-        # extract the vertices and faces
-        verts = mc.verts.numpy()
-        faces = mc.indices.numpy().reshape(-1, 3)
-
-    elif backend == "skimage":
-        try:
-            import skimage  # noqa: F401 for docs
-            from skimage import measure
-        except ImportError:
-            raise ImportError("Install `scikit-image` to use `skimage` backend.")
-
-        verts, faces, _, _ = measure.marching_cubes(
-            field, threshold, spacing=[field.shape[0], field.shape[1], field.shape[2]]
-        )
-
-    # save stl file
-    mesh_data = np.zeros(faces.shape[0], dtype=mesh.Mesh.dtype)
-
-    for i, f in enumerate(faces):
-        for j in range(3):
-            mesh_data["vectors"][i][j] = verts[f[j], :]
-
-    surface_mesh = mesh.Mesh(mesh_data)
-    surface_mesh.save(filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ all = [
     "netcdf4>=1.6.3",
     "ruamel.yaml>=0.17.22",
     "scikit-learn>=1.0.2",
+    "scikit-image>=0.24.0",
     "warp-lang>=0.6.0",
     "vtk>=9.2.6",
     "pyvista>=0.40.1",

--- a/test/utils/test_mesh_utils.py
+++ b/test/utils/test_mesh_utils.py
@@ -177,7 +177,7 @@ def test_mesh_utils(tmp_path, pytestconfig):
     assert os.path.exists(tmp_path / "converted/random.vtp")
 
 
-@import_or_fail(["warp", "skimage"])
+@import_or_fail(["warp", "skimage", "stl"])
 @pytest.mark.parametrize("backend", ["warp", "skimage"])
 def test_stl_gen(pytestconfig, backend, download_stl, tmp_path):
 

--- a/test/utils/test_mesh_utils.py
+++ b/test/utils/test_mesh_utils.py
@@ -16,10 +16,36 @@
 
 import os
 import random
+import urllib
 
+import numpy as np
+import pytest
 from pytest_utils import import_or_fail
+from stl import mesh
 
-from modulus.utils.mesh import combine_vtp_files, convert_tesselated_files_in_directory
+from modulus.utils.mesh import (
+    combine_vtp_files,
+    convert_tesselated_files_in_directory,
+    sdf_to_stl,
+)
+from modulus.utils.sdf import signed_distance_field
+
+
+@pytest.fixture
+def download_stl(tmp_path):
+    url = "https://upload.wikimedia.org/wikipedia/commons/4/43/Stanford_Bunny.stl"
+
+    parsed_url = urllib.parse.urlparse(url)
+    if parsed_url.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme '{parsed_url.scheme}' is not permitted.")
+
+    file_path = tmp_path / "Stanford_Bunny.stl"
+
+    # Download the STL file
+    urllib.request.urlretrieve(url, file_path)  # noqa: S310
+
+    # Return the path to the downloaded file
+    return file_path
 
 
 @import_or_fail(["vtk"])
@@ -149,3 +175,48 @@ def test_mesh_utils(tmp_path, pytestconfig):
         "obj2vtp", tmp_dir, output_dir=tmp_path / "converted"
     )
     assert os.path.exists(tmp_path / "converted/random.vtp")
+
+
+@import_or_fail(["warp", "skimage"])
+@pytest.mark.parametrize("backend", ["warp", "skimage"])
+def test_stl_gen(pytestconfig, backend, download_stl, tmp_path):
+
+    bunny_mesh = mesh.Mesh.from_file(str(download_stl))
+
+    vertices = np.array(bunny_mesh.vectors, dtype=np.float64)
+    vertices_3d = vertices.reshape(-1, 3)
+    vert_indices = np.arange((vertices_3d.shape[0]))
+
+    bounds = {
+        "x": (np.min(vertices_3d[:, 0]), np.max(vertices_3d[:, 0])),
+        "y": (np.min(vertices_3d[:, 1]), np.max(vertices_3d[:, 1])),
+        "z": (np.min(vertices_3d[:, 2]), np.max(vertices_3d[:, 2])),
+    }
+
+    res = {k: v[1] - v[0] for k, v in bounds.items()}
+    min_res = min(res.values()) / 100
+    n = [int((bounds[k][1] - bounds[k][0] + 2) // min_res) for k in bounds.keys()]
+    x = np.linspace(bounds["x"][0] - 1, bounds["x"][1] + 1, n[0], dtype=np.float64)
+    y = np.linspace(bounds["y"][0] - 1, bounds["y"][1] + 1, n[1], dtype=np.float64)
+    z = np.linspace(bounds["z"][0] - 1, bounds["z"][1] + 1, n[2], dtype=np.float64)
+    xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
+
+    coords = np.concatenate(
+        [xx.reshape(-1, 1), yy.reshape(-1, 1), zz.reshape(-1, 1)], axis=1
+    )
+
+    sdf_test = signed_distance_field(
+        vertices_3d, vert_indices, coords.flatten()
+    ).numpy()
+    output_filename = tmp_path / "output_stl.stl"
+    sdf_to_stl(
+        sdf_test.reshape(n[0], n[1], n[2]),
+        threshold=0.0,
+        backend=backend,
+        filename=output_filename,
+    )
+
+    # read the saved stl
+    saved_stl = mesh.Mesh.from_file(str(output_filename))
+
+    assert saved_stl.vectors is not None

--- a/test/utils/test_sdf.py
+++ b/test/utils/test_sdf.py
@@ -115,8 +115,9 @@ def test_sdf(pytestconfig):
     np.testing.assert_allclose(sdf_hit_point_id.numpy(), [3, 0], atol=1e-7)
 
 
-@import_or_fail("warp")
-def test_stl_gen(pytestconfig, download_stl, tmp_path):
+@import_or_fail(["warp", "skimage"])
+@pytest.mark.parametrize("backend", ["warp", "skimage"])
+def test_stl_gen(pytestconfig, backend, download_stl, tmp_path):
 
     bunny_mesh = mesh.Mesh.from_file(str(download_stl))
 
@@ -146,7 +147,12 @@ def test_stl_gen(pytestconfig, download_stl, tmp_path):
         vertices_3d, vert_indices, coords.flatten()
     ).numpy()
     output_filename = tmp_path / "output_stl.stl"
-    sdf_to_stl(sdf_test.reshape(n[0], n[1], n[2]), filename=output_filename)
+    sdf_to_stl(
+        sdf_test.reshape(n[0], n[1], n[2]),
+        threshold=0.0,
+        backend=backend,
+        filename=output_filename,
+    )
 
     # read the saved stl
     saved_stl = mesh.Mesh.from_file(str(output_filename))

--- a/test/utils/test_sdf.py
+++ b/test/utils/test_sdf.py
@@ -15,31 +15,11 @@
 # limitations under the License.
 # ruff: noqa: E402
 
-import urllib.request
 
 import numpy as np
-import pytest
 from pytest_utils import import_or_fail
-from stl import mesh
 
-from modulus.utils.sdf import sdf_to_stl, signed_distance_field
-
-
-@pytest.fixture
-def download_stl(tmp_path):
-    url = "https://upload.wikimedia.org/wikipedia/commons/4/43/Stanford_Bunny.stl"
-
-    parsed_url = urllib.parse.urlparse(url)
-    if parsed_url.scheme not in ("http", "https"):
-        raise ValueError(f"URL scheme '{parsed_url.scheme}' is not permitted.")
-
-    file_path = tmp_path / "Stanford_Bunny.stl"
-
-    # Download the STL file
-    urllib.request.urlretrieve(url, file_path)  # noqa: S310
-
-    # Return the path to the downloaded file
-    return file_path
+from modulus.utils.sdf import signed_distance_field
 
 
 def tet_verts(flip_x=1):
@@ -113,48 +93,3 @@ def test_sdf(pytestconfig):
         atol=1e-7,
     )
     np.testing.assert_allclose(sdf_hit_point_id.numpy(), [3, 0], atol=1e-7)
-
-
-@import_or_fail(["warp", "skimage"])
-@pytest.mark.parametrize("backend", ["warp", "skimage"])
-def test_stl_gen(pytestconfig, backend, download_stl, tmp_path):
-
-    bunny_mesh = mesh.Mesh.from_file(str(download_stl))
-
-    vertices = np.array(bunny_mesh.vectors, dtype=np.float64)
-    vertices_3d = vertices.reshape(-1, 3)
-    vert_indices = np.arange((vertices_3d.shape[0]))
-
-    bounds = {
-        "x": (np.min(vertices_3d[:, 0]), np.max(vertices_3d[:, 0])),
-        "y": (np.min(vertices_3d[:, 1]), np.max(vertices_3d[:, 1])),
-        "z": (np.min(vertices_3d[:, 2]), np.max(vertices_3d[:, 2])),
-    }
-
-    res = {k: v[1] - v[0] for k, v in bounds.items()}
-    min_res = min(res.values()) / 100
-    n = [int((bounds[k][1] - bounds[k][0] + 2) // min_res) for k in bounds.keys()]
-    x = np.linspace(bounds["x"][0] - 1, bounds["x"][1] + 1, n[0], dtype=np.float64)
-    y = np.linspace(bounds["y"][0] - 1, bounds["y"][1] + 1, n[1], dtype=np.float64)
-    z = np.linspace(bounds["z"][0] - 1, bounds["z"][1] + 1, n[2], dtype=np.float64)
-    xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
-
-    coords = np.concatenate(
-        [xx.reshape(-1, 1), yy.reshape(-1, 1), zz.reshape(-1, 1)], axis=1
-    )
-
-    sdf_test = signed_distance_field(
-        vertices_3d, vert_indices, coords.flatten()
-    ).numpy()
-    output_filename = tmp_path / "output_stl.stl"
-    sdf_to_stl(
-        sdf_test.reshape(n[0], n[1], n[2]),
-        threshold=0.0,
-        backend=backend,
-        filename=output_filename,
-    )
-
-    # read the saved stl
-    saved_stl = mesh.Mesh.from_file(str(output_filename))
-
-    assert saved_stl.vectors is not None

--- a/test/utils/test_sdf.py
+++ b/test/utils/test_sdf.py
@@ -132,10 +132,10 @@ def test_stl_gen(pytestconfig, download_stl, tmp_path):
 
     res = {k: v[1] - v[0] for k, v in bounds.items()}
     min_res = min(res.values()) / 100
-    n = [int((bounds[k][1] - bounds[k][0] + 0.1) // min_res) for k in bounds.keys()]
-    x = np.linspace(bounds["x"][0] - 0.5, bounds["x"][1] + 0.5, n[0], dtype=np.float64)
-    y = np.linspace(bounds["y"][0] - 0.5, bounds["y"][1] + 0.5, n[1], dtype=np.float64)
-    z = np.linspace(bounds["z"][0] - 0.5, bounds["z"][1] + 0.5, n[2], dtype=np.float64)
+    n = [int((bounds[k][1] - bounds[k][0] + 2) // min_res) for k in bounds.keys()]
+    x = np.linspace(bounds["x"][0] - 1, bounds["x"][1] + 1, n[0], dtype=np.float64)
+    y = np.linspace(bounds["y"][0] - 1, bounds["y"][1] + 1, n[1], dtype=np.float64)
+    z = np.linspace(bounds["z"][0] - 1, bounds["z"][1] + 1, n[2], dtype=np.float64)
     xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
 
     coords = np.concatenate(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Adds a simple utility to generate STL from SDF. 

<img width="1565" alt="image" src="https://github.com/user-attachments/assets/ddcf8a93-8c10-4381-bdbe-814a1f2f945a">

Also makes some changes to help with CI

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->