### PR TITLE
Fix mlflow import errors

### DIFF
--- a/docs/test_scripts/test_mlflow_logger.py
+++ b/docs/test_scripts/test_mlflow_logger.py
@@ -3,7 +3,8 @@ import torch
 
 import modulus
 from modulus.datapipes.benchmarks.darcy import Darcy2D
-from modulus.launch.logging import LaunchLogger, PythonLogger, initialize_mlflow
+from modulus.launch.logging import LaunchLogger, PythonLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 from modulus.metrics.general.mse import mse
 from modulus.models.fno.fno import FNO
 

--- a/examples/cfd/darcy_fno/train_fno_darcy.py
+++ b/examples/cfd/darcy_fno/train_fno_darcy.py
@@ -26,7 +26,8 @@ from modulus.datapipes.benchmarks.darcy import Darcy2D
 from modulus.distributed import DistributedManager
 from modulus.utils import StaticCaptureTraining, StaticCaptureEvaluateNoGrad
 from modulus.launch.utils import load_checkpoint, save_checkpoint
-from modulus.launch.logging import PythonLogger, LaunchLogger, initialize_mlflow
+from modulus.launch.logging import PythonLogger, LaunchLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 
 from validator import GridValidator
 

--- a/examples/cfd/darcy_nested_fnos/train_nested_darcy.py
+++ b/examples/cfd/darcy_nested_fnos/train_nested_darcy.py
@@ -33,9 +33,8 @@ from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
     LaunchLogger,
-    initialize_mlflow,
 )
-
+from modulus.launch.logging.mlflow import initialize_mlflow
 from utils import NestedDarcyDataset, GridValidator
 
 

--- a/examples/cfd/mhd_pino/train_mhd.py
+++ b/examples/cfd/mhd_pino/train_mhd.py
@@ -31,7 +31,6 @@ from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.launch.logging import (
     PythonLogger,
     LaunchLogger,
-    initialize_mlflow,
     initialize_wandb,
 )
 from modulus.sym.hydra import to_absolute_path

--- a/examples/cfd/mhd_pino/train_mhd_vec_pot.py
+++ b/examples/cfd/mhd_pino/train_mhd_vec_pot.py
@@ -31,7 +31,6 @@ from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.launch.logging import (
     PythonLogger,
     LaunchLogger,
-    initialize_mlflow,
     initialize_wandb,
 )
 from modulus.sym.hydra import to_absolute_path

--- a/examples/cfd/mhd_pino/train_mhd_vec_pot_tfno.py
+++ b/examples/cfd/mhd_pino/train_mhd_vec_pot_tfno.py
@@ -31,7 +31,6 @@ from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.launch.logging import (
     PythonLogger,
     LaunchLogger,
-    initialize_mlflow,
     initialize_wandb,
 )
 from modulus.sym.hydra import to_absolute_path

--- a/examples/weather/diagnostic/train_diagnostic_precip.py
+++ b/examples/weather/diagnostic/train_diagnostic_precip.py
@@ -17,7 +17,8 @@
 import hydra
 from omegaconf import OmegaConf
 
-from modulus.launch.logging import LaunchLogger, initialize_mlflow
+from modulus.launch.logging import LaunchLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 
 from diagnostic import data, distribute, loss, models, precip, train
 

--- a/examples/weather/dlwp/train_dlwp.py
+++ b/examples/weather/dlwp/train_dlwp.py
@@ -32,7 +32,8 @@ from modulus.utils import StaticCaptureTraining, StaticCaptureEvaluateNoGrad
 from modulus.models.dlwp import DLWP
 
 from cube_sphere_plotter_no_subplots import cube_sphere_plotter
-from modulus.launch.logging import LaunchLogger, PythonLogger, initialize_mlflow
+from modulus.launch.logging import LaunchLogger, PythonLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 import modulus.utils.zenith_angle as zenith_angle
 from torch.optim.lr_scheduler import ReduceLROnPlateau

--- a/examples/weather/fcn_afno/train_era5.py
+++ b/examples/weather/fcn_afno/train_era5.py
@@ -28,7 +28,8 @@ from modulus.datapipes.climate import ERA5HDF5Datapipe
 from modulus.distributed import DistributedManager
 from modulus.utils import StaticCaptureTraining, StaticCaptureEvaluateNoGrad
 
-from modulus.launch.logging import LaunchLogger, PythonLogger, initialize_mlflow
+from modulus.launch.logging import LaunchLogger, PythonLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 
 try:

--- a/examples/weather/pangu_weather/train_pangu_era5.py
+++ b/examples/weather/pangu_weather/train_pangu_era5.py
@@ -28,7 +28,8 @@ from modulus.datapipes.climate import ERA5HDF5Datapipe
 from modulus.distributed import DistributedManager
 from modulus.utils import StaticCaptureTraining, StaticCaptureEvaluateNoGrad
 
-from modulus.launch.logging import LaunchLogger, PythonLogger, initialize_mlflow
+from modulus.launch.logging import LaunchLogger, PythonLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 
 try:

--- a/examples/weather/pangu_weather/train_pangu_lite_era5.py
+++ b/examples/weather/pangu_weather/train_pangu_lite_era5.py
@@ -28,7 +28,8 @@ from modulus.datapipes.climate import ERA5HDF5Datapipe
 from modulus.distributed import DistributedManager
 from modulus.utils import StaticCaptureTraining, StaticCaptureEvaluateNoGrad
 
-from modulus.launch.logging import LaunchLogger, PythonLogger, initialize_mlflow
+from modulus.launch.logging import LaunchLogger, PythonLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 
 try:

--- a/examples/weather/unified_recipe/train.py
+++ b/examples/weather/unified_recipe/train.py
@@ -46,8 +46,8 @@ from modulus.launch.logging import (
     LaunchLogger,
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_mlflow,
 )
+from modulus.launch.logging.mlflow import initialize_mlflow
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.utils import StaticCaptureEvaluateNoGrad, StaticCaptureTraining
 

--- a/modulus/launch/logging/__init__.py
+++ b/modulus/launch/logging/__init__.py
@@ -16,5 +16,4 @@
 
 from .console import PythonLogger, RankZeroLoggingWrapper
 from .launch import LaunchLogger
-from .mlflow import initialize_mlflow
 from .wandb import initialize_wandb


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Fixes the mlflow import errors by removing `initialize_mlflow` from the init file. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->