### PR TITLE
Add gradient clipping to Static Capture Utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Graph Transformer processor for GraphCast/GenCast.
 - Utility to generate STL from Signed Distance Field.
+- Added gradient clipping to StaticCapture utilities.
 
 ### Changed
 

--- a/modulus/utils/capture.py
+++ b/modulus/utils/capture.py
@@ -252,6 +252,7 @@ class _StaticCapture(object):
 
         if not self.eval:
             # In training mode output should be the loss
+            self.scaler.scale(output).backward()
             if self.gradient_clip_norm is not None:
                 if self.use_autocast:
                     self.scaler.unscale_(self.optim)
@@ -259,7 +260,6 @@ class _StaticCapture(object):
                     self.model.parameters(), self.gradient_clip_norm
                 )
 
-            self.scaler.scale(output).backward()
         return output
 
     def _init_amp_scaler(

--- a/modulus/utils/capture.py
+++ b/modulus/utils/capture.py
@@ -56,14 +56,14 @@ class _StaticCapture(object):
     def __init__(
         self,
         model: "modulus.Module",
-        optim: Union[optim, None] = None,
-        logger: Union[Logger, None] = None,
+        optim: Optional[optim] = None,
+        logger: Optional[Logger] = None,
         use_graphs: bool = True,
         use_autocast: bool = True,
         use_gradscaler: bool = True,
         cuda_graph_warmup: int = 11,
         amp_type: Union[float16, bfloat16] = torch.float16,
-        gradient_clip_norm: float | None = None,
+        gradient_clip_norm: Optional[float] = None,
         label: Optional[str] = None,
     ):
         self.logger = logger if logger else self.logger
@@ -254,8 +254,7 @@ class _StaticCapture(object):
             # In training mode output should be the loss
             self.scaler.scale(output).backward()
             if self.gradient_clip_norm is not None:
-                if self.use_autocast:
-                    self.scaler.unscale_(self.optim)
+                self.scaler.unscale_(self.optim)
                 torch.nn.utils.clip_grad_norm_(
                     self.model.parameters(), self.gradient_clip_norm
                 )
@@ -347,7 +346,7 @@ class StaticCaptureTraining(_StaticCapture):
         Modulus Model
     optim : torch.optim
         Optimizer
-    logger : Union[Logger, None], optional
+    logger : Optional[Logger], optional
         Modulus Launch Logger, by default None
     use_graphs : bool, optional
         Toggle CUDA graphs if supported by model, by default True
@@ -357,9 +356,9 @@ class StaticCaptureTraining(_StaticCapture):
         Number of warmup steps for cuda graphs, by default 11
     amp_type : Union[float16, bfloat16], optional
         Auto casting type for AMP, by default torch.float16
-    gradient_clip_norm : Union[float, None], optional
+    gradient_clip_norm : Optional[float], optional
         Threshold for gradient clipping
-    label : Optional[str, None], optional
+    label : Optional[str], optional
         Static capture checkpoint label, by default None
 
     Raises
@@ -405,12 +404,12 @@ class StaticCaptureTraining(_StaticCapture):
         self,
         model: "modulus.Module",
         optim: torch.optim,
-        logger: Union[Logger, None] = None,
+        logger: Optional[Logger] = None,
         use_graphs: bool = True,
         use_amp: bool = True,
         cuda_graph_warmup: int = 11,
         amp_type: Union[float16, bfloat16] = torch.float16,
-        gradient_clip_norm: float | None = None,
+        gradient_clip_norm: Optional[float] = None,
         label: Optional[str] = None,
     ):
         super().__init__(
@@ -439,7 +438,7 @@ class StaticCaptureEvaluateNoGrad(_StaticCapture):
     ----------
     model : modulus.models.Module
         Modulus Model
-    logger : Union[Logger, None], optional
+    logger : Optional[Logger], optional
         Modulus Launch Logger, by default None
     use_graphs : bool, optional
         Toggle CUDA graphs if supported by model, by default True
@@ -449,7 +448,7 @@ class StaticCaptureEvaluateNoGrad(_StaticCapture):
         Number of warmup steps for cuda graphs, by default 11
     amp_type : Union[float16, bfloat16], optional
         Auto casting type for AMP, by default torch.float16
-    label : Optional[str, None], optional
+    label : Optional[str], optional
         Static capture checkpoint label, by default None
 
     Raises
@@ -482,7 +481,7 @@ class StaticCaptureEvaluateNoGrad(_StaticCapture):
     def __init__(
         self,
         model: "modulus.Module",
-        logger: Union[Logger, None] = None,
+        logger: Optional[Logger] = None,
         use_graphs: bool = True,
         use_amp: bool = True,
         cuda_graph_warmup: int = 11,

--- a/test/utils/test_capture.py
+++ b/test/utils/test_capture.py
@@ -64,6 +64,7 @@ def logger():
     "use_amp, amp_type",
     [(True, torch.float16), (True, torch.bfloat16), (False, torch.float16)],
 )
+@pytest.mark.parametrize("gradient_clip_norm", [None, 4.0])
 def test_capture_training(
     model,
     logger,
@@ -72,6 +73,7 @@ def test_capture_training(
     use_graphs,
     use_amp,
     amp_type,
+    gradient_clip_norm,
 ):
     # Initialize the DistributedManager first since StaticCaptureTraining uses it
     DistributedManager.initialize()
@@ -98,6 +100,7 @@ def test_capture_training(
         use_amp=use_amp,
         cuda_graph_warmup=1,
         amp_type=amp_type,
+        gradient_clip_norm=gradient_clip_norm,
     )
     def training_step(invar, outvar):
         predvar = model(invar)
@@ -121,6 +124,7 @@ def test_capture_training(
         optim=optim,
         logger=logger,
         cuda_graph_warmup=1,
+        gradient_clip_norm=gradient_clip_norm,
     )
     def training_step(invar, outvar):
         predvar = model(invar)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Adds `gradient_clip_norm` to the static capture utilities. This should be backward compatible with existing examples.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.
