### PR TITLE
Capture unused HRRRMiniDataset kwargs

### DIFF
--- a/examples/generative/corrdiff/datasets/hrrrmini.py
+++ b/examples/generative/corrdiff/datasets/hrrrmini.py
@@ -38,6 +38,7 @@ class HRRRMiniDataset(DownscalingDataset):
         input_variables: Union[List[str], None] = None,
         output_variables: Union[List[str], None] = None,
         invariant_variables: Union[List[str], None] = ("elev_mean", "lsm_mean"),
+        **kwargs,
     ):
         # load data
         (self.input, self.input_variables) = _load_dataset(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Tiny fix to `HRRRMiniDataset` for training CorrDiff-Mini. At https://github.com/NVIDIA/modulus/blob/main/examples/generative/corrdiff/datasets/dataset.py#L64, we add `"train"` and `"all_times"` kwargs to the dataset config, which are not understood by the `HRRRMiniDataset` constructor. Adding `**kwargs` to the constructor to avoid the following error:

```
Traceback (most recent call last):
  File "/workspace/repos/modulus/examples/generative/corrdiff/train.py", line 82, in main
    ) = init_train_valid_datasets_from_config(
  File "/workspace/repos/modulus/examples/generative/corrdiff/datasets/dataset.py", line 66, in init_train_valid_datasets_from_config
    (valid_dataset, valid_dataset_iter) = init_dataset_from_config(
  File "/workspace/repos/modulus/examples/generative/corrdiff/datasets/dataset.py", line 88, in init_dataset_from_config
    dataset_obj = dataset_init_func(**dataset_cfg)
TypeError: HRRRMiniDataset.__init__() got an unexpected keyword argument 'train'
```

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

@jleinonen 