### PR TITLE
Fix Timezone to UTC in Datapipes and Cosine Zenith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactored CorrDiff training recipe for improved usability
+- Fixed timezone calculation in datapipe cosine zenith utility.
 
 ### Deprecated
 

--- a/modulus/datapipes/climate/climate.py
+++ b/modulus/datapipes/climate/climate.py
@@ -23,6 +23,7 @@ from itertools import chain
 import h5py
 import netCDF4 as nc
 import numpy as np
+import pytz
 import torch
 
 try:
@@ -729,7 +730,9 @@ class ClimateDaliExternalSource(ABC):
 
         # Load sequence of timestamps
         year = self.start_year + year_idx
-        start_time = datetime(year, 1, 1) + timedelta(hours=int(in_idx) * self.dt)
+        start_time = datetime(year, 1, 1, tzinfo=pytz.utc) + timedelta(
+            hours=int(in_idx) * self.dt
+        )
         timestamps = np.array(
             [
                 (start_time + timedelta(hours=i * self.stride * self.dt)).timestamp()

--- a/modulus/datapipes/climate/era5_hdf5.py
+++ b/modulus/datapipes/climate/era5_hdf5.py
@@ -33,6 +33,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple, Union
 
+import pytz
+
 from modulus.datapipes.climate.utils.invariant import latlon_grid
 from modulus.datapipes.climate.utils.zenith_angle import cos_zenith_angle
 
@@ -572,7 +574,9 @@ class ERA5DaliExternalSource:
         # Load sequence of timestamps
         if self.use_cos_zenith:
             year = self.start_year + year_idx
-            start_time = datetime(year, 1, 1) + timedelta(hours=int(in_idx) * self.dt)
+            start_time = datetime(year, 1, 1, tzinfo=pytz.utc) + timedelta(
+                hours=int(in_idx) * self.dt
+            )
             timestamps = np.array(
                 [
                     (

--- a/modulus/datapipes/climate/utils/zenith_angle.py
+++ b/modulus/datapipes/climate/utils/zenith_angle.py
@@ -76,7 +76,7 @@ def cos_zenith_angle(
 
 def _days_from_2000(model_time):  # pragma: no cover
     """Get the days since year 2000."""
-    return (3600 + model_time - DATETIME_2000) / (24.0 * 3600.0)
+    return (model_time - DATETIME_2000) / (24.0 * 3600.0)
 
 
 def _greenwich_mean_sidereal_time(model_time):

--- a/modulus/datapipes/climate/utils/zenith_angle.py
+++ b/modulus/datapipes/climate/utils/zenith_angle.py
@@ -30,6 +30,7 @@
 import datetime
 
 import numpy as np
+import pytz
 
 try:
     import nvidia.dali as dali
@@ -41,7 +42,7 @@ except ImportError:
     )
 
 RAD_PER_DEG = np.pi / 180.0
-DATETIME_2000 = datetime.datetime(2000, 1, 1, 12, 0, 0).timestamp()
+DATETIME_2000 = datetime.datetime(2000, 1, 1, 12, 0, 0, tzinfo=pytz.utc).timestamp()
 
 
 def _dali_mod(a, b):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
This PR fixes timezones in the ERA5 datapipes and in the related cosine zenith utilities. There was a discrepancy because of this that caused a `+3600` to appear to be correct, but was likely an artifact due to improperly set time zones.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.
