### PR TITLE
Fix `shapely` import errors

### DIFF
--- a/modulus/metrics/cae/cfd.py
+++ b/modulus/metrics/cae/cfd.py
@@ -18,14 +18,6 @@ from typing import List, Tuple, Union
 
 import numpy as np
 import pyvista as pv
-
-try:
-    import shapely  # noqa: F401 for docs
-except ImportError:
-    raise ImportError(
-        "These metrics require shapely, install it using `pip install shapely`."
-    )
-
 import torch
 from numpy.fft import fft, fftfreq
 
@@ -51,6 +43,13 @@ def compute_frontal_area(mesh: pv.PolyData, direction: str = "x"):
     frontal area: float
         Frontal area of the mesh in the given direction
     """
+    try:
+        import shapely  # noqa: F401 for docs
+    except ImportError:
+        raise ImportError(
+            "These metrics require shapely, install it using `pip install shapely`."
+        )
+
     direction_map = {
         "x": ((1, 0, 0), [1, 2]),
         "y": ((0, 1, 0), [0, 2]),

--- a/test/metrics/test_metrics_cfd.py
+++ b/test/metrics/test_metrics_cfd.py
@@ -22,7 +22,6 @@ from pytest_utils import import_or_fail
 
 from modulus.metrics.cae.cfd import (
     compute_force_coefficients,
-    compute_frontal_area,
     compute_p_q_r,
     compute_tke_spectrum,
     dominant_freq_calc,
@@ -49,6 +48,8 @@ def generate_box(level=500):
 
 @import_or_fail(["pyvista", "shapely"])
 def test_frontal_area(generate_sphere, pytestconfig):
+    from modulus.metrics.cae.cfd import compute_frontal_area
+
     sphere = generate_sphere
 
     # area of circle


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Fixes shapely import errors in the deployment image which does not have shapely

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->