### PR TITLE
Expose all torch.distributed.init_process_group parameters in the DistributedManager

### DIFF
--- a/test/distributed/test_manager.py
+++ b/test/distributed/test_manager.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+from datetime import timedelta
 
 import pytest
 import torch
@@ -38,6 +39,29 @@ def test_manager():
     os.environ["RANK"] = "0"
     os.environ["WORLD_SIZE"] = "1"
     DistributedManager.initialize()
+    print(DistributedManager())
+
+    manager = DistributedManager()
+
+    assert manager.is_initialized()
+    assert (
+        manager.distributed == torch.distributed.is_available()
+    ), "Manager should be in serial mode"
+    assert manager.rank == 0
+    assert manager.world_size == 1
+    assert manager.local_rank == 0
+
+    DistributedManager.cleanup()
+    del os.environ["RANK"]
+    del os.environ["WORLD_SIZE"]
+
+
+def test_manager_timeout():
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "12345"
+    os.environ["RANK"] = "0"
+    os.environ["WORLD_SIZE"] = "1"
+    DistributedManager.initialize(timeout=timedelta(minutes=60))
     print(DistributedManager())
 
     manager = DistributedManager()


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Adding kwargs to DistributedManager.initialize to pass down to torch.distributed.init_process_group. Added a test to specifically check that the `timeout` parameter gets passed down to torch.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->

None