### PR TITLE
Add W&B id parameter to the init function to enable resuming.

### DIFF
--- a/modulus/launch/logging/wandb.py
+++ b/modulus/launch/logging/wandb.py
@@ -43,6 +43,7 @@ def initialize_wandb(
     sync_tensorboard: bool = False,
     save_code: bool = False,
     resume: str = None,
+    wandb_id: str = None,
     config=None,
     mode: Literal["offline", "online", "disabled"] = "offline",
     results_dir: str = None,
@@ -66,6 +67,11 @@ def initialize_wandb(
     resume: str, optional
         Sets the resuming behavior. Options: "allow", "must", "never", "auto" or None,
         by default None.
+    wandb_id: str, optional
+        A unique ID for this run, used for resuming. Used in conjunction with `resume`
+        parameter to enable experiment resuming.
+        See W&B documentation for more details:
+        https://docs.wandb.ai/guides/runs/resuming/
     config : optional
         a dictionary-like object for saving inputs , like hyperparameters.
         If dict, argparse or absl.flags, it will load the key value pairs into the
@@ -107,6 +113,7 @@ def initialize_wandb(
         dir=wandb_dir,
         group=group,
         save_code=save_code,
+        id=wandb_id,
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

Add W&B id parameter to the init function to enable resuming. Providing W&B id allows to have a single graph for multiple runs such as the following graph that contains data from 5 experiments with resuming:

![image](https://github.com/user-attachments/assets/909d0e99-931f-4f28-b7f1-6670b2fa3e73)

Note that the actual id generation and storage is left up to the user since it can be different.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->