### PR TITLE
Add `import_or_fail` decorator to lagranginan tests

### DIFF
--- a/test/datapipes/test_lagrangian.py
+++ b/test/datapipes/test_lagrangian.py
@@ -60,6 +60,7 @@ def test_lagrangian_dataset_constructor(data_dir, device, pytestconfig):
     assert graph.ndata["y"].shape[-1] > 0  # node targets
 
 
+@import_or_fail(["tensorflow", "dgl"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_graph_construction(device):
     from modulus.datapipes.gnn.lagrangian_dataset import compute_edge_index

--- a/test/datapipes/test_lagrangian.py
+++ b/test/datapipes/test_lagrangian.py
@@ -62,7 +62,7 @@ def test_lagrangian_dataset_constructor(data_dir, device, pytestconfig):
 
 @import_or_fail(["tensorflow", "dgl"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_graph_construction(device):
+def test_graph_construction(device, pytestconfig):
     from modulus.datapipes.gnn.lagrangian_dataset import compute_edge_index
 
     mesh_pos = torch.tensor([[0.0, 0.0], [0.01, 0.0], [1.0, 1.0]], device=device)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
The `test_graph_construction` test was missing the decorator

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->