### PR TITLE
Fix HPX scaling not supporting coupled HPX dataloader

### DIFF
--- a/modulus/datapipes/healpix/timeseries_dataset.py
+++ b/modulus/datapipes/healpix/timeseries_dataset.py
@@ -241,9 +241,9 @@ class TimeSeriesDataset(Dataset, Datapipe):
 
         # REMARK: we remove the xarray overhead from these
         try:
-            self.input_scaling = scaling_da.sel(index=self.ds.channel_in.values).rename(
-                {"index": "channel_in"}
-            )
+            self.input_scaling = scaling_da.sel(
+                index=self.ds.channel_out.values
+            ).rename({"index": "channel_in"})
             self.input_scaling = {
                 "mean": np.expand_dims(
                     self.input_scaling["mean"].to_numpy(), (0, 2, 3, 4)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
When coupled HPX dataloader used the scaling in HPX dataloader, the channel of input included the coupled channels which make the scaling size not matching to input array.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->