### PR TITLE
Fix the ocean coupled model training hang problem

### DIFF
--- a/modulus/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/modulus/datapipes/healpix/coupledtimeseries_dataset.py
@@ -271,9 +271,9 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
             np.transpose(x, axes=(0, 3, 1, 2, 4, 5)) for x in inputs_result
         ]
 
-        if self.constants is not None:
+        if "constants" in self.ds.data_vars:
             # Add the constants as [F, C, H, W]
-            inputs_result.append(self.constants)
+            inputs_result.append(self.get_constants())
 
         # append integrated couplings
         inputs_result.append(integrated_couplings)

--- a/modulus/datapipes/healpix/timeseries_dataset.py
+++ b/modulus/datapipes/healpix/timeseries_dataset.py
@@ -194,20 +194,6 @@ class TimeSeriesDataset(Dataset, Datapipe):
         if self.scaling:
             self._get_scaling_da()
 
-        # setup constants
-        if "constants" in self.ds.data_vars:
-            # extract from ds:
-            const = self.ds.constants.values
-
-            if self.constant_scaling:
-                const = (const - self.constant_scaling["mean"]) / self.constant_scaling[
-                    "std"
-                ]
-
-            # transpose to match new format:
-            # [C, F, H, W] -> [F, C, H, W]
-            self.constants = np.transpose(const, axes=(1, 0, 2, 3))
-
     def get_constants(self):
         """Returns the constants used in this dataset
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request
Moving HPX dataloader extracting constants to `__getitem__` so to avoid hanging.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->