### PR TITLE
Revert unconditional EDMLoss to positional arg

### DIFF
--- a/modulus/metrics/diffusion/loss.py
+++ b/modulus/metrics/diffusion/loss.py
@@ -265,7 +265,7 @@ class EDMLoss:
                 augment_labels=augment_labels,
             )
         else:
-            D_yn = net(y + n, sigma, labels=labels, augment_labels=augment_labels)
+            D_yn = net(y + n, sigma, labels, augment_labels=augment_labels)
         loss = weight * ((D_yn - y) ** 2)
         return loss
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Previously `EDMLoss` passed the `labels` as a positional argument to the network call; this pattern was updated to use an explicit keyword arg when supporting conditional models, but the keyword `labels` used in unconditional case is not always defined/correct. This is a simple fix to revert unconditional `EDMLoss` usage to the previous behavior. I've tested this with the existing `examples/generative/diffusion` examples and a ReGenAI prototype, both succeeding.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->