### PR TITLE
Move to experiment-based Hydra config in L-MGN example

### DIFF
--- a/examples/cfd/lagrangian_mgn/conf/config.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/config.yaml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - /logging/python: default
+  - override hydra/job_logging: disabled  # We use rank-aware logger configuration instead.
+  - _self_
+
+hydra:
+  run:
+    dir: ${output}
+  output_subdir: hydra  # Default is .hydra which causes files not being uploaded in W&B.
+
+# Dimensionality of the problem (2D or 3D).
+dim: 2
+
+# Main output directory.
+output: outputs
+
+# The directory to search for checkpoints to continue training.
+resume_dir: ${output}
+
+# The dataset directory must be set either in command line or config.
+data:
+  data_dir: ???
+  train:
+    split: train
+  valid:
+    split: valid
+  test:
+    split: test
+
+# The loss should be set in the experiment.
+loss: ???
+
+# The optimizer should be set in the experiment.
+optimizer: ???
+
+# The scheduler should be set in the experiment.
+lr_scheduler: ???
+
+train:
+  batch_size: 20
+  epochs: 20
+  checkpoint_save_freq: 5
+  dataloader:
+    batch_size: ${..batch_size}
+    shuffle: true
+    num_workers: 1
+    pin_memory: true
+    drop_last: true
+
+test:
+  batch_size: 1
+  device: cuda
+  dataloader:
+    batch_size: ${..batch_size}
+    shuffle: false
+    num_workers: 1
+    pin_memory: true
+    drop_last: false
+
+compile:
+  enabled: false
+  args:
+    backend: inductor
+
+amp:
+  enabled: false
+
+loggers:
+  wandb:
+    _target_: loggers.WandBLogger
+    project: meshgraphnet
+    entity: modulus
+    name: l-mgn
+    group: l-mgn
+    mode: disabled
+    dir: ${output}
+    id:
+    wandb_key:
+    watch_model: false
+
+inference:
+  frame_skip: 1
+  frame_interval: 1

--- a/examples/cfd/lagrangian_mgn/conf/data/lagrangian_dataset.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/data/lagrangian_dataset.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: modulus.datapipes.gnn.lagrangian_dataset.LagrangianDataset
+_convert_: all
+
+name: ${data.name}
+data_dir: ${data.data_dir}
+split: ???
+num_samples: ???
+num_history: 5
+num_steps: 600
+num_node_types: 6
+noise_std: 0.0003
+radius: 0.015
+dt: 0.0025

--- a/examples/cfd/lagrangian_mgn/conf/experiment/goop.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/experiment/goop.yaml
@@ -1,0 +1,45 @@
+# @package _global_
+
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - /data@data.train: lagrangian_dataset
+  - /data@data.valid: lagrangian_dataset
+  - /data@data.test: lagrangian_dataset
+  - /model: mgn_2d
+  - /loss: mseloss
+  - /optimizer: fused_adam
+  - /lr_scheduler: cosine
+
+data:
+  name: Goop
+  num_node_types: 9
+  train:
+    num_samples: 1000
+    num_steps: 395  # 400 - ${num_history}
+    num_node_types: ${..num_node_types}
+  valid:
+    num_samples: 30
+    num_steps: 100
+    num_node_types: ${..num_node_types}
+  test:
+    num_samples: 30
+    num_steps: 100
+    num_node_types: ${..num_node_types}
+
+model:
+  input_dim_nodes: 25  # 9 node types instead of 6.

--- a/examples/cfd/lagrangian_mgn/conf/experiment/sand.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/experiment/sand.yaml
@@ -1,0 +1,45 @@
+# @package _global_
+
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - /data@data.train: lagrangian_dataset
+  - /data@data.valid: lagrangian_dataset
+  - /data@data.test: lagrangian_dataset
+  - /model: mgn_2d
+  - /loss: mseloss
+  - /optimizer: fused_adam
+  - /lr_scheduler: cosine
+
+data:
+  name: Sand
+  num_node_types: 9
+  train:
+    num_samples: 1000
+    num_steps: 315  # 320 - ${num_history}
+    num_node_types: ${..num_node_types}
+  valid:
+    num_samples: 30
+    num_steps: 100
+    num_node_types: ${..num_node_types}
+  test:
+    num_samples: 30
+    num_steps: 100
+    num_node_types: ${..num_node_types}
+
+model:
+  input_dim_nodes: 25  # 9 node types instead of 6.

--- a/examples/cfd/lagrangian_mgn/conf/experiment/water.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/experiment/water.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - /data@data.train: lagrangian_dataset
+  - /data@data.valid: lagrangian_dataset
+  - /data@data.test: lagrangian_dataset
+  - /model: mgn_2d
+  - /loss: mseloss
+  - /optimizer: fused_adam
+  - /lr_scheduler: cosine
+
+data:
+  name: Water
+  train:
+    num_samples: 1000
+    num_steps: 995  # 1000 - ${num_history}
+  valid:
+    num_samples: 30
+    num_steps: 200
+  test:
+    num_samples: 30
+    num_steps: 200

--- a/examples/cfd/lagrangian_mgn/conf/experiment/water_3d.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/experiment/water_3d.yaml
@@ -1,0 +1,48 @@
+# @package _global_
+
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - /data@data.train: lagrangian_dataset
+  - /data@data.valid: lagrangian_dataset
+  - /data@data.test: lagrangian_dataset
+  - /model: mgn_3d
+  - /loss: mseloss
+  - /optimizer: fused_adam
+  - /lr_scheduler: cosine
+
+dim: 3
+
+data:
+  name: Water
+  dt: 0.005
+  radius: 0.035
+  train:
+    num_samples: 1000
+    num_steps: 795  # 800 - ${num_history}
+    radius: ${..radius}
+    dt: ${..dt}
+  valid:
+    num_samples: 100
+    num_steps: 195
+    radius: ${..radius}
+    dt: ${..dt}
+  test:
+    num_samples: 100
+    num_steps: 195
+    radius: ${..radius}
+    dt: ${..dt}

--- a/examples/cfd/lagrangian_mgn/conf/experiment/water_ramps.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/experiment/water_ramps.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - /data@data.train: lagrangian_dataset
+  - /data@data.valid: lagrangian_dataset
+  - /data@data.test: lagrangian_dataset
+  - /model: mgn_2d
+  - /loss: mseloss
+  - /optimizer: fused_adam
+  - /lr_scheduler: cosine
+
+data:
+  name: WaterRamps
+  train:
+    num_samples: 1000
+    num_steps: 595  # 600 - ${num_history}
+  valid:
+    num_samples: 30
+    num_steps: 200
+  test:
+    num_samples: 30
+    num_steps: 200

--- a/examples/cfd/lagrangian_mgn/conf/logging/python/default.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/logging/python/default.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standard Python logging configuration, as described here:
+# https://docs.python.org/3.10/library/logging.config.html
+
+version: 1
+disable_existing_loggers: false
+
+output: ???
+rank: ???
+rank0_only: true
+base_filename: train
+
+formatters:
+  default:
+    (): loggers.TermColorFormatter
+    format: "[%(asctime)s - %(name)s - %(levelname)s] %(message)s"
+    datefmt: "%H:%M:%S"
+    log_colors:
+      DEBUG: blue
+      INFO: light_blue
+      WARNING: light_yellow
+      ERROR: light_red
+      CRITICAL: red
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: ${...loggers.lmgn.level}
+    formatter: default
+
+  file:
+    class: logging.FileHandler
+    filename: ${...output}/${...base_filename}_${...rank}.log
+    level: ${...loggers.lmgn.level}
+    formatter: default
+
+loggers:
+  root:
+    level: INFO
+    handlers: [console, file]
+  lmgn:
+    handlers: [console, file]
+    level: INFO
+    propagate: false

--- a/examples/cfd/lagrangian_mgn/conf/loss/mseloss.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/loss/mseloss.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: torch.nn.MSELoss
+reduction: mean

--- a/examples/cfd/lagrangian_mgn/conf/lr_scheduler/cosine.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/lr_scheduler/cosine.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: torch.optim.lr_scheduler.CosineAnnealingLR
+
+T_max:  # if not set via the command line, will be set in the code.
+eta_min: 1e-6

--- a/examples/cfd/lagrangian_mgn/conf/lr_scheduler/exponentiallr.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/lr_scheduler/exponentiallr.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: torch.optim.lr_scheduler.ExponentialLR
+gamma: 0.99985

--- a/examples/cfd/lagrangian_mgn/conf/lr_scheduler/onecyclelr.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/lr_scheduler/onecyclelr.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: torch.optim.lr_scheduler.OneCycleLR
+
+max_lr: 1e-4
+total_steps:  # if not set via the command line, will be set in the code.

--- a/examples/cfd/lagrangian_mgn/conf/model/mgn.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/model/mgn.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: modulus.models.meshgraphnet.MeshGraphNet
+_convert_: all
+
+input_dim_nodes: ???  # can be set in 2D/3D versions of the model.
+input_dim_edges: ???
+output_dim: ???
+processor_size: 10
+aggregation: sum
+hidden_dim_node_encoder: 256
+hidden_dim_edge_encoder: 256
+hidden_dim_node_decoder: 256
+mlp_activation_fn: relu
+do_concat_trick: false
+num_processor_checkpoint_segments: 0
+recompute_activation: false
+
+# See MeshGraphNet implementation for more details and additional arguments.

--- a/examples/cfd/lagrangian_mgn/conf/model/mgn_2d.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/model/mgn_2d.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - mgn   # Use MGN model as a base.
+
+input_dim_nodes: 22  # 2 (pos) + 2*5 (history of velocity) + 4 boundary features + 6 (node type)
+output_dim: 2 # 2 acceleration
+input_dim_edges: 3 # 2 displacement + 1 distance

--- a/examples/cfd/lagrangian_mgn/conf/model/mgn_3d.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/model/mgn_3d.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - mgn   # Use MGN model as a base.
+
+input_dim_nodes: 30 # 3 (pos) + 3*5 (history of velocity) + 6 boundary features + 6 (node type)
+output_dim: 3 # 3 acceleration
+input_dim_edges: 4 # 3 displacement + 1 distance

--- a/examples/cfd/lagrangian_mgn/conf/optimizer/adam.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/optimizer/adam.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_target_: torch.optim.Adam
+lr: 1e-4
+weight_decay: 1e-5

--- a/examples/cfd/lagrangian_mgn/conf/optimizer/fused_adam.yaml
+++ b/examples/cfd/lagrangian_mgn/conf/optimizer/fused_adam.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - adam
+
+_target_: apex.optimizers.FusedAdam

--- a/examples/cfd/lagrangian_mgn/inference.py
+++ b/examples/cfd/lagrangian_mgn/inference.py
@@ -14,56 +14,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
-import time
+
 import hydra
-from hydra.utils import to_absolute_path
+from hydra.utils import instantiate, to_absolute_path
 
 import dgl
 from dgl.dataloading import GraphDataLoader
-import matplotlib.pyplot as plt
+
+import matplotlib
 from matplotlib import animation
-from matplotlib import tri as mtri
-from matplotlib.patches import Rectangle
-import matplotlib  #
+from matplotlib import pyplot as plt
 
 matplotlib.use("TkAgg")  # for plotting
 
-import numpy as np
-from networkx import radius
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
+
 import torch
 
-from modulus.models.meshgraphnet import MeshGraphNet
-from modulus.datapipes.gnn.lagrangian_dataset import LagrangianDataset, graph_update
-from modulus.launch.logging import PythonLogger
+from modulus.datapipes.gnn.lagrangian_dataset import graph_update
 from modulus.launch.utils import load_checkpoint
+
+from loggers import init_python_logging
+
+
+logger = logging.getLogger("lmgn")
 
 
 class MGNRollout:
-    def __init__(self, cfg: DictConfig, logger: PythonLogger):
-        self.num_test_samples = cfg.num_test_samples
-        self.num_test_time_steps = cfg.num_test_time_steps
-        self.dim = cfg.num_output_features
-        self.frame_skip = cfg.frame_skip
+    def __init__(self, cfg: DictConfig):
+        self.num_steps = cfg.data.test.num_steps
+        self.dim = cfg.dim
+        self.frame_skip = cfg.inference.frame_skip
         self.num_history = 5
-        self.num_node_type = 6
+        self.num_node_type = cfg.data.test.num_node_types
         self.plotting_index = 0
-        self.radius = cfg.radius
+        self.radius = cfg.data.test.radius
 
         # set device
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = cfg.test.device
         logger.info(f"Using {self.device} device")
 
         # instantiate dataset
-        self.dataset = LagrangianDataset(
-            name="Water",
-            data_dir=to_absolute_path(cfg.data_dir),
-            split="valid",
-            num_samples=cfg.num_test_samples,
-            num_steps=cfg.num_test_time_steps,
-            radius=cfg.radius,
-        )
+        logger.info("Loading the test dataset...")
+        self.dataset = instantiate(cfg.data.test)
+        logger.info(f"Using {len(self.dataset)} test samples.")
+
         self.dim = self.dataset.dim
         self.dt = self.dataset.dt
         self.bound = self.dataset.bound
@@ -80,33 +77,24 @@ class MGNRollout:
         # instantiate dataloader
         self.dataloader = GraphDataLoader(
             self.dataset,
-            batch_size=1,
-            shuffle=False,
-            drop_last=False,
+            **cfg.test.dataloader,
         )
 
         # instantiate the model
-        self.model = MeshGraphNet(
-            cfg.num_input_features,
-            cfg.num_edge_features,
-            cfg.num_output_features,
-            cfg.processor_size,
-            mlp_activation_fn=cfg.activation,
-            do_concat_trick=cfg.do_concat_trick,
-            num_processor_checkpoint_segments=cfg.num_processor_checkpoint_segments,
-            recompute_activation=cfg.recompute_activation,
-        )
-        if cfg.jit:
-            self.model = torch.jit.script(self.model).to(self.device)
-        else:
-            self.model = self.model.to(self.device)
+        logger.info("Creating the model...")
+        # instantiate the model
+        self.model = instantiate(cfg.model)
+
+        if cfg.compile.enabled:
+            self.model = torch.compile(self.model, **cfg.compile.args)
+        self.model = self.model.to(self.device)
 
         # enable train mode
         self.model.eval()
 
         # load checkpoint
         load_checkpoint(
-            to_absolute_path(cfg.ckpt_path),
+            to_absolute_path(cfg.resume_dir),
             models=self.model,
             device=self.device,
         )
@@ -248,7 +236,7 @@ class MGNRollout:
 
     def animate2d(self, num):
         num *= self.frame_skip
-        num = num + self.plotting_index * self.num_test_time_steps
+        num = num + self.plotting_index * self.num_steps
         node_type = self.node_type[num]
         node_type = (
             torch.argmax(node_type, dim=1).numpy() / self.num_node_type
@@ -290,7 +278,7 @@ class MGNRollout:
 
     def animate3d(self, num):
         num *= self.frame_skip
-        num = num + self.plotting_index * self.num_test_time_steps
+        num = num + self.plotting_index * self.num_steps
         node_type = self.node_type[num]
         node_type = (
             torch.argmax(node_type, dim=1).numpy() / self.num_node_type
@@ -335,28 +323,31 @@ class MGNRollout:
         return plt
 
 
-@hydra.main(version_base="1.3", config_path="conf", config_name="config_2d")
+@hydra.main(version_base="1.3", config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
-    logger = PythonLogger("main")  # General python logger
-    logger.file_logging()
+    init_python_logging(cfg, base_filename="inference")
+    logger.info(f"Config summary:\n{OmegaConf.to_yaml(cfg, sort_keys=True)}")
+
     logger.info("Rollout started...")
-    rollout = MGNRollout(cfg, logger)
+    rollout = MGNRollout(cfg)
 
     # test on dataset
     rollout.predict()
 
     # unit test
-    # rollout.unit_test_example(t=cfg.num_test_time_steps)
+    # rollout.unit_test_example(t=cfg.num_steps)
 
     # compute the roll out loss
     pred = torch.stack([tensor.reshape(-1) for tensor in rollout.pred], dim=0)
     target = torch.stack([tensor.reshape(-1) for tensor in rollout.exact], dim=0)
     loss = torch.nn.functional.mse_loss(pred, target)
-    print(f"the rollout loss is {loss}")
+    logger.info(f"The rollout loss is {loss:.5f}")
 
     # plot the roll out loss
     error_plt = rollout.plot_error(pred, target)
-    error_plt.savefig("animations/error.png")
+    out_dir = os.path.join(cfg.output, "animations")
+    os.makedirs(out_dir, exist_ok=True)
+    error_plt.savefig(os.path.join(out_dir, "error.png"))
 
     # plot
     if cfg.dim == 2:
@@ -364,19 +355,19 @@ def main(cfg: DictConfig) -> None:
         ani = animation.FuncAnimation(
             rollout.fig,
             rollout.animate2d,
-            frames=(cfg.num_test_time_steps - 5) // cfg.frame_skip,
-            interval=cfg.frame_interval,
+            frames=(cfg.data.test.num_steps - 5) // cfg.inference.frame_skip,
+            interval=cfg.inference.frame_interval,
         )
     elif cfg.dim == 3:
         rollout.init_animation3d(index=0)
         ani = animation.FuncAnimation(
             rollout.fig,
             rollout.animate3d,
-            frames=(cfg.num_test_time_steps - 5) // cfg.frame_skip,
-            interval=cfg.frame_interval,
+            frames=(cfg.data.test.num_steps - 5) // cfg.inference.frame_skip,
+            interval=cfg.inference.frame_interval,
         )
 
-    ani.save("animations/animation.gif")
+    ani.save(os.path.join(out_dir, "animation.gif"))
     logger.info(f"Created animation")
 
 

--- a/examples/cfd/lagrangian_mgn/loggers.py
+++ b/examples/cfd/lagrangian_mgn/loggers.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from abc import ABC, abstractmethod
+import functools
+import logging
+import os
+from typing import Any, Mapping, Optional
+
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from termcolor import colored
+
+from torch import nn
+
+import wandb
+
+from modulus.distributed import DistributedManager
+
+logger = logging.getLogger("lmgn")
+
+
+class TermColorFormatter(logging.Formatter):
+    """Custom logging formatter that colors the log output based on log level."""
+
+    def __init__(
+        self,
+        fmt: Optional[str] = None,
+        datefmt: Optional[str] = None,
+        style: str = "%",
+        validate: bool = True,
+        log_colors: Optional[Mapping[str, str]] = None,
+        *,
+        defaults=None,
+    ):
+        super().__init__(fmt, datefmt, style, validate, defaults=defaults)
+        self.log_colors = log_colors if log_colors is not None else {}
+
+    def format(self, record):
+        log_message = super().format(record)
+        color = self.log_colors.get(record.levelname, "white")
+        return colored(log_message, color)
+
+
+def init_python_logging(
+    config: DictConfig, rank: int = 0, base_filename: str = "train"
+) -> None:
+    """Initializes Python logging."""
+
+    pylog_cfg = OmegaConf.select(config, "logging.python")
+    if pylog_cfg is None:
+        return
+
+    # Set up Python loggers.
+    pylog_cfg.output = config.output
+    pylog_cfg.rank = rank
+    pylog_cfg.base_filename = base_filename
+    # Enable logging only on rank 0, if requested.
+    if pylog_cfg.rank0_only and pylog_cfg.rank != 0:
+        pylog_cfg.handlers = {}
+        for l in pylog_cfg.loggers.values():
+            l.handlers = []
+    # Configure logging.
+    logging.config.dictConfig(OmegaConf.to_container(pylog_cfg, resolve=True))
+
+
+def rank0(func):
+    """Decorator that allows the function to be executed only in rank 0 process."""
+
+    @functools.wraps(func)
+    def rank0_only(*args, **kwargs):
+        if DistributedManager().rank == 0:
+            func(*args, **kwargs)
+
+    return rank0_only
+
+
+class ExperimentLogger(ABC):
+    """Provides unified interface to a logger."""
+
+    @abstractmethod
+    def log_scalar(self, tag: str, value: float, step: int) -> None:
+        pass
+
+    @abstractmethod
+    def log_image(self, tag: str, value, step: int) -> None:
+        pass
+
+    @abstractmethod
+    def log(self, data: Mapping[str, Any], step: int) -> None:
+        pass
+
+    @abstractmethod
+    def watch_model(self, model: nn.Module) -> None:
+        pass
+
+
+class WandBLogger(ExperimentLogger):
+    """Wrapper for Weights & Biases logger."""
+
+    def __init__(self, **kwargs) -> None:
+        if DistributedManager().rank != 0:
+            return
+
+        if wandb_key := kwargs.pop("wandb_key", None) is not None:
+            logger.warning("Passing W&B key via config is not recommended.")
+            wandb.login(key=wandb_key)
+
+        # If wandb_id is not provided to resume the experiment,
+        # create new id if wandb_id.txt does not exist,
+        # otherwise - load id from the file.
+        if wandb_id := kwargs.pop("id", None) is None:
+            wandb_id_file = os.path.join(kwargs["dir"], "wandb_id.txt")
+            if not os.path.exists(wandb_id_file):
+                wandb_id = wandb.util.generate_id()
+                with open(wandb_id_file, "w", encoding="utf-8") as f:
+                    f.write(wandb_id)
+                logger.info(f"Starting new wandb run: {wandb_id}")
+            else:
+                with open(wandb_id_file, encoding="utf-8") as f:
+                    wandb_id = f.read()
+                logger.info(f"Resuming wandb run: {wandb_id}")
+        resume = kwargs.pop("resume", "allow")
+
+        self.watch = kwargs.pop("watch_model", False)
+
+        wandb.init(**kwargs, id=wandb_id, resume=resume)
+
+    def log_scalar(self, tag: str, value: float, step: int) -> None:
+        wandb.log({tag: value}, step=step)
+
+    def log_image(self, tag: str, value, step: int) -> None:
+        wandb.log({tag: wandb.Image(value)}, step=step)
+
+    def log(self, data: Mapping[str, Any], step: int) -> None:
+        wandb.log(data, step=step)
+
+    def watch_model(self, model: nn.Module):
+        if self.watch:
+            wandb.watch(model)
+
+
+class CompositeLogger(ExperimentLogger):
+    """Wraps a list of loggers providing unified interface."""
+
+    loggers: dict[str, ExperimentLogger] = None
+
+    def __init__(self, config: DictConfig) -> None:
+        if DistributedManager().rank != 0:
+            self.loggers = {}
+            return
+        # Instantiate loggers only when running on rank 0.
+        self.loggers = instantiate(config.loggers)
+
+    @rank0
+    def log_scalar(self, tag: str, value: float, step: int) -> None:
+        for l in self.loggers.values():
+            l.log_scalar(tag, value, step)
+
+    @rank0
+    def log_image(self, tag: str, value: float, step: int) -> None:
+        for l in self.loggers.values():
+            l.log_image(tag, value, step)
+
+    @rank0
+    def log(self, data: Mapping[str, Any], step: int) -> None:
+        for l in self.loggers.values():
+            l.log(data, step)
+
+    @rank0
+    def watch_model(self, model: nn.Module) -> None:
+        for l in self.loggers.values():
+            l.watch_model(model)

--- a/examples/cfd/lagrangian_mgn/train.py
+++ b/examples/cfd/lagrangian_mgn/train.py
@@ -14,98 +14,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
-import hydra
-from hydra.utils import to_absolute_path
-import torch
-import wandb
+import logging
 import time
 
 from dgl.dataloading import GraphDataLoader
 
-from omegaconf import DictConfig
+import hydra
+from hydra.utils import instantiate, to_absolute_path
+from omegaconf import DictConfig, OmegaConf
+
+import torch
 from torch.cuda.amp import GradScaler, autocast
 from torch.nn.parallel import DistributedDataParallel
 
-from modulus.datapipes.gnn.lagrangian_dataset import LagrangianDataset
 from modulus.distributed.manager import DistributedManager
-from modulus.launch.logging import (
-    PythonLogger,
-    RankZeroLoggingWrapper,
-    initialize_wandb,
-)
 from modulus.launch.utils import load_checkpoint, save_checkpoint
-from modulus.models.meshgraphnet import MeshGraphNet
+
+from loggers import CompositeLogger, ExperimentLogger, init_python_logging
+
+
+logger = logging.getLogger("lmgn")
+
+# Experiment logger will be set later during initialization.
+elogger: ExperimentLogger = None
 
 
 class MGNTrainer:
-    def __init__(self, cfg: DictConfig, rank_zero_logger: RankZeroLoggingWrapper):
+    def __init__(self, cfg: DictConfig):
         assert DistributedManager.is_initialized()
         self.dist = DistributedManager()
-        self.amp = cfg.amp
-        self.radius = cfg.radius
-        self.dt = cfg.dt
+
+        self.dt = cfg.data.train.dt
         self.dim = cfg.dim
-        self.gravity = torch.zeros(self.dim, device=self.dist.device)
-        self.gravity[-1] = -9.8
+
+        self.amp = cfg.amp.enabled
 
         # MGN with recompute_activation currently supports only SiLU activation function.
-        mlp_act = cfg.activation
-        if cfg.recompute_activation and cfg.activation.lower() != "silu":
+        mlp_act = cfg.model.mlp_activation_fn
+        if cfg.model.recompute_activation and mlp_act.lower() != "silu":
             raise ValueError(
                 f"recompute_activation only supports SiLU activation function, "
-                f"but got {cfg.activation}. Please either set activation='silu' "
+                f"but got {mlp_act}. Please either set activation='silu' "
                 f"or disable recompute_activation."
             )
 
         # instantiate dataset
-        self.dataset = LagrangianDataset(
-            name="Water",
-            data_dir=to_absolute_path(cfg.data_dir),
-            split="train",
-            num_samples=cfg.num_training_samples,
-            num_steps=cfg.num_training_time_steps,
-            radius=cfg.radius,
-            dt=cfg.dt,
-        )
+        logger.info("Loading the training dataset...")
+        self.dataset = instantiate(cfg.data.train)
+        logger.info(f"Using {len(self.dataset)} training samples.")
         self.dataset.set_normalizer_device(device=self.dist.device)
         self.time_integrator = self.dataset.time_integrator
 
         # instantiate dataloader
         self.dataloader = GraphDataLoader(
             self.dataset,
-            batch_size=cfg.batch_size,
-            shuffle=True,
-            drop_last=True,
-            pin_memory=True,
+            **cfg.train.dataloader,
             use_ddp=self.dist.world_size > 1,
-            num_workers=cfg.num_dataloader_workers,
         )
 
         # instantiate the model
-        self.model = MeshGraphNet(
-            cfg.num_input_features,
-            cfg.num_edge_features,
-            cfg.num_output_features,
-            cfg.processor_size,
-            mlp_activation_fn=mlp_act,
-            do_concat_trick=cfg.do_concat_trick,
-            num_processor_checkpoint_segments=cfg.num_processor_checkpoint_segments,
-            recompute_activation=cfg.recompute_activation,
-            # aggregation="mean",
-        )
-        if cfg.jit:
-            if not self.model.meta.jit:
-                raise ValueError("MeshGraphNet is not yet JIT-compatible.")
-            self.model = torch.jit.script(self.model).to(self.dist.device)
+        logger.info("Creating the model...")
+        # instantiate the model
+        self.model = instantiate(cfg.model)
+
+        if cfg.compile.enabled:
+            self.model = torch.compile(self.model, **cfg.compile.args).to(
+                self.dist.device
+            )
         else:
             self.model = self.model.to(self.dist.device)
-        if cfg.watch_model and not cfg.jit and self.dist.rank == 0:
-            wandb.watch(self.model)
+            elogger.watch_model(self.model)
 
         # distributed data parallel for multi-node training
-        if self.dist.world_size > 1:
+        if self.dist.distributed:
             self.model = DistributedDataParallel(
                 self.model,
                 device_ids=[self.dist.local_rank],
@@ -117,49 +98,37 @@ class MGNTrainer:
         # enable train mode
         self.model.train()
 
-        # instantiate loss, optimizer, and scheduler
-        # self.criterion = self.l2loss
-        self.criterion = torch.nn.MSELoss()
+        # instantiate loss
+        self.criterion = instantiate(cfg.loss)
 
-        self.optimizer = None
-        try:
-            if cfg.use_apex:
-                from apex.optimizers import FusedAdam
+        # instantiate optimizer, and scheduler
+        self.optimizer = instantiate(cfg.optimizer, self.model.parameters())
 
-                self.optimizer = FusedAdam(self.model.parameters(), lr=cfg.lr)
-        except ImportError:
-            rank_zero_logger.warning(
-                "NVIDIA Apex (https://github.com/nvidia/apex) is not installed, "
-                "FusedAdam optimizer will not be used."
-            )
-        if self.optimizer is None:
-            self.optimizer = torch.optim.Adam(
-                self.model.parameters(), lr=cfg.lr, weight_decay=1e-5
-            )
-        rank_zero_logger.info(f"Using {self.optimizer.__class__.__name__} optimizer")
+        num_iterations = cfg.train.epochs * len(self.dataloader)
+        lrs_cfg = cfg.lr_scheduler
+        lrs_with_num_iter = {
+            "torch.optim.lr_scheduler.CosineAnnealingLR": "T_max",
+            "torch.optim.lr_scheduler.OneCycleLR": "total_steps",
+        }
+        if (num_iter_key := lrs_with_num_iter.get(lrs_cfg._target_)) is not None:
+            if lrs_cfg[num_iter_key] is None:
+                lrs_cfg[num_iter_key] = num_iterations
+        self.scheduler = instantiate(cfg.lr_scheduler, self.optimizer)
 
-        num_iteration = (
-            cfg.epochs
-            * cfg.num_training_samples
-            * cfg.num_training_time_steps
-            // cfg.batch_size
-        )
-        self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-            self.optimizer, T_max=num_iteration, eta_min=cfg.lr_min
-        )
         self.scaler = GradScaler()
 
         # load checkpoint
         if self.dist.world_size > 1:
             torch.distributed.barrier()
         self.epoch_init = load_checkpoint(
-            to_absolute_path(cfg.ckpt_path),
+            to_absolute_path(cfg.resume_dir),
             models=self.model,
             optimizer=self.optimizer,
             scheduler=self.scheduler,
             scaler=self.scaler,
             device=self.dist.device,
         )
+        self.epoch_init += 1
 
     def train(self, graph):
         graph = graph.to(self.dist.device)
@@ -202,38 +171,24 @@ class MGNTrainer:
             loss.backward()
             self.optimizer.step()
 
-    def l2loss(self, input, target, p=2, eps=1e-5):
-        input = input.flatten(start_dim=1)
-        target = target.flatten(start_dim=1)
-        l2loss = torch.norm(input - target, dim=1, p=p) / (
-            torch.norm(target, dim=1, p=p) + eps
-        )
-        l2loss = torch.mean(l2loss)
-        return l2loss
 
-
-@hydra.main(version_base="1.3", config_path="conf", config_name="config_2d")
+@hydra.main(version_base="1.3", config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     # initialize distributed manager
     DistributedManager.initialize()
     dist = DistributedManager()
 
-    # Initialize loggers.
-    wandb.login(key=cfg.wandb_key)
-    initialize_wandb(
-        project=cfg.wandb_project,
-        entity=cfg.wandb_entity,
-        name=cfg.wandb_name,
-        mode=cfg.wandb_mode,
-    )  # Wandb logger
-    logger = PythonLogger("main")  # General python logger
-    rank_zero_logger = RankZeroLoggingWrapper(logger, dist)  # Rank 0 logger
-    rank_zero_logger.file_logging()
+    init_python_logging(cfg, dist.rank)
+    logger.info(f"Config summary:\n{OmegaConf.to_yaml(cfg, sort_keys=True)}")
 
-    trainer = MGNTrainer(cfg, rank_zero_logger)
+    # Initialize loggers.
+    global elogger
+    elogger = CompositeLogger(cfg)
+
+    trainer = MGNTrainer(cfg)
     start = time.time()
-    rank_zero_logger.info("Training started...")
-    for epoch in range(trainer.epoch_init, cfg.epochs):
+    logger.info("Training started...")
+    for epoch in range(trainer.epoch_init, cfg.train.epochs + 1):
         loss_list = []
         loss_pos_list = []
         loss_vel_list = []
@@ -248,12 +203,14 @@ def main(cfg: DictConfig) -> None:
         mean_loss_pos = sum(loss_pos_list) / len(loss_pos_list)
         mean_loss_vel = sum(loss_vel_list) / len(loss_vel_list)
         mean_loss_acc = sum(loss_acc_list) / len(loss_acc_list)
-        rank_zero_logger.info(
-            f"epoch: {epoch}, loss: {mean_loss:10.3e}, "
+        last_lr = trainer.scheduler.get_last_lr()[0]
+        logger.info(
+            f"epoch: {epoch:5,}, loss: {mean_loss:10.3e}, "
             f"position loss: {mean_loss_pos:10.3e}, "
             f"velocity loss: {mean_loss_vel:10.3e}, "
             f"acceleration loss: {mean_loss_acc:10.3e}, "
-            f"time per epoch: {(time.time()-start):10.3e}"
+            f"lr: {last_lr:10.3e}, "
+            f"time per epoch: {(time.time() - start):10.3e}"
         )
         losses = {
             "loss": mean_loss,
@@ -261,14 +218,15 @@ def main(cfg: DictConfig) -> None:
             "loss_vel": mean_loss_vel,
             "loss_acc": mean_loss_acc,
         }
-        wandb.log(losses)
+        elogger.log(losses, epoch)
+        elogger.log_scalar("lr", last_lr, epoch)
 
         # save checkpoint
         if dist.world_size > 1:
             torch.distributed.barrier()
-        if dist.rank == 0:
+        if dist.rank == 0 and epoch % cfg.train.checkpoint_save_freq == 0:
             save_checkpoint(
-                to_absolute_path(cfg.ckpt_path),
+                cfg.output,
                 models=trainer.model,
                 optimizer=trainer.optimizer,
                 scheduler=trainer.scheduler,
@@ -277,7 +235,7 @@ def main(cfg: DictConfig) -> None:
             )
             logger.info(f"Saved model on rank {dist.rank}")
         start = time.time()
-    rank_zero_logger.info("Training completed!")
+    logger.info("Training completed!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

* moved to Hydra experiment config which simplifies configuring different dataset experiments in L-MGN.
* The example now supports 15+ datasets that are used in the original paper.
* Unified training and inference script configuration which are now both experiment-driven which guarantees coherency.
* Refactored logging since W&B is not available anymore.

Results on different datasets: 
* Water:
    <img src=https://github.com/user-attachments/assets/88f1ac70-766d-4c12-bc70-a3588493867c width=400>
* Water 3D:
    <img src=https://github.com/user-attachments/assets/bb62355e-96e9-4d3f-8e79-715d5af046a3 width=400>
* Sand:
    <img src=https://github.com/user-attachments/assets/318b7545-7a5d-4437-9aba-14609cfbf730 width=400>
* Water ramps:
    <img src=https://github.com/user-attachments/assets/45ba9bda-f523-42ba-9302-e811f678eb22 width=400>

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->