### PR TITLE
Retraining recipe for DoMINO and removing fixed non-dimensionalization from domino datapipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DoMINO model architecture, datapipe and training recipe
 - Added matrix decomposition scheme to improve graph partitioning
 - DrivAerML dataset support in FIGConvNet example.
+- Retraining recipe for DoMINO from a pretrained model checkpoint
 
 ### Changed
 
 - Refactored StormCast training example
 - Enhancements and bug fixes to DoMINO model and training example
 - Enhancement to parameterize DoMINO model with inlet velocity
+- Moved non-dimensionaliztion out of domino datapipe to datapipe in domino example
 
 ### Deprecated
 

--- a/examples/cfd/external_aerodynamics/domino/README.md
+++ b/examples/cfd/external_aerodynamics/domino/README.md
@@ -47,9 +47,26 @@ To train and test the DoMINO model on AWS dataset, follow these steps:
 4. Run `train.py` to start the training. Modify data, train and model keys in config file.
 
 5. Run `test.py` to test on `.vtp` / `.vtu`. Predictions are written to the same file.
- Modify eval key in config file.
+ Modify eval key in config file to specify checkpoint, input and output directory.
 
 6. Download the validation results (saved in form of point clouds in `.vtp` / `.vtu` format),
+   and visualize in Paraview.
+
+## Retraining recipe for DoMINO model
+
+To enable retraining the DoMINO model from a pre-trained checkpoint, follow the steps:
+
+1. Add the pre-trained checkpoints in the resume_dir defined in `conf/config.yaml`.
+
+2. Add the volume and surface scaling factors to the output dir defined in  `conf/config.yaml`.
+
+3. Run `retraining.py` for specified number of epochs to retrain model at a small
+ learning rate starting from checkpoint.
+
+4. Run `test.py` to test on `.vtp` / `.vtu`. Predictions are written to the same file.
+ Modify eval key in config file to specify checkpoint, input and output directory.
+
+5. Download the validation results (saved in form of point clouds in `.vtp` / `.vtu` format),
    and visualize in Paraview.
 
 ## Guidelines for training DoMINO model

--- a/examples/cfd/external_aerodynamics/domino/src/conf/config.yaml
+++ b/examples/cfd/external_aerodynamics/domino/src/conf/config.yaml
@@ -53,7 +53,7 @@ variables:
       nutMeanTrim: scalar
 
 model:
-  model_type: surface # train which model? surface, volume, combined
+  model_type: combined # train which model? surface, volume, combined
   loss_function: "mse" # mse or rmse
   interp_res: [128, 64, 48] # resolution of latent space
   use_sdf_in_basis_func: true # SDF in basis function network
@@ -67,7 +67,7 @@ model:
   use_only_normals: true # Use only surface normals and not surface area
   integral_loss_scaling_factor: 0 # Scale integral loss by this factor
   normalization: min_max_scaling # or mean_std_scaling
-  encode_parameters: false # encode inlet velocity and air density in the model
+  encode_parameters: true # encode inlet velocity and air density in the model
   geometry_rep: # Hyperparameters for geometry representation network
     base_filters: 16
     geo_conv:
@@ -103,7 +103,8 @@ train: # Training configurable parameters
   sampler:
     shuffle: true
     drop_last: false
-
+  checkpoint_dir: /lustre/rranade/modulus_dev/modulus_forked/modulus/examples/cfd/external_aerodynamics/domino/outputs/AWS_Dataset/3/models/
+  
 val: # Validation configurable parameters
   dataloader:
     batch_size: 1
@@ -115,9 +116,10 @@ val: # Validation configurable parameters
 eval: # Testing configurable parameters
   test_path: /lustre/rranade/benchmarking/drivaer_aws_surface_test_new/
   save_path: /lustre/rranade/domino/mesh_predictions_surf_final1/
+  checkpoint_name: DoMINO.0.50.pt
 
 data_processor: # Data processor configurable parameters
   kind: drivaer_aws # must be either drivesim or drivaer_aws
   output_dir: /lustre/rranade/modulus_dev/data/volume_data/
   input_dir: /lustre/datasets/drivaer_aws/drivaer_data_full/
-  num_processors: 24
+  num_processors: 12

--- a/examples/cfd/external_aerodynamics/domino/src/openfoam_datapipe.py
+++ b/examples/cfd/external_aerodynamics/domino/src/openfoam_datapipe.py
@@ -142,6 +142,19 @@ class OpenFoamDataset(Dataset):
                 polydata, self.volume_variables
             )
             volume_fields = np.concatenate(volume_fields, axis=-1)
+
+            # Non-dimensionalize volume fields
+            volume_fields[:, :3] = volume_fields[:, :3] / STREAM_VELOCITY
+            volume_fields[:, 3:4] = volume_fields[:, 3:4] / (
+                AIR_DENSITY * STREAM_VELOCITY**2.0
+            )
+
+            volume_fields[:, 4:5] = volume_fields[:, 4:5] / (
+                AIR_DENSITY * STREAM_VELOCITY**2.0
+            )
+            volume_fields[:, 5:] = volume_fields[:, 5:] / (
+                STREAM_VELOCITY * length_scale
+            )
         else:
             volume_fields = None
             volume_coordinates = None
@@ -171,6 +184,9 @@ class OpenFoamDataset(Dataset):
             surface_normals = (
                 surface_normals / np.linalg.norm(surface_normals, axis=1)[:, np.newaxis]
             )
+
+            # Non-dimensionalize surface fields
+            surface_fields = surface_fields / (AIR_DENSITY * STREAM_VELOCITY**2.0)
         else:
             surface_fields = None
             surface_coordinates = None

--- a/examples/cfd/external_aerodynamics/domino/src/retraining.py
+++ b/examples/cfd/external_aerodynamics/domino/src/retraining.py
@@ -557,6 +557,7 @@ def train_epoch(
 
     return last_loss
 
+
 @hydra.main(version_base="1.3", config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     input_path = cfg.data.input_dir
@@ -821,7 +822,7 @@ def main(cfg: DictConfig) -> None:
                 scaler=scaler,
                 epoch=str(
                     best_vloss.item()
-                ), # hacky way of using epoch to store metadata
+                ),  # hacky way of using epoch to store metadata
             )
         print(
             f"Device { dist.device}, Best val loss {best_vloss}, Time taken {time.time() - start_time}"

--- a/examples/cfd/external_aerodynamics/domino/src/test.py
+++ b/examples/cfd/external_aerodynamics/domino/src/test.py
@@ -369,9 +369,7 @@ def main(cfg: DictConfig):
     model = torch.compile(model, disable=True)
 
     checkpoint = torch.load(
-        to_absolute_path(
-            os.path.join(cfg.resume_dir, cfg.eval.checkpoint_name)
-        ),
+        to_absolute_path(os.path.join(cfg.resume_dir, cfg.eval.checkpoint_name)),
         map_location=dist.device,
     )
 

--- a/examples/cfd/external_aerodynamics/domino/src/test.py
+++ b/examples/cfd/external_aerodynamics/domino/src/test.py
@@ -263,7 +263,7 @@ def test_step(data_dict, model, device, cfg, vol_factors, surf_factors):
                         :, start_idx:end_idx
                     ]
                     geo_encoding_local = model.module.geo_encoding_local_surface(
-                        geo_encoding, surface_mesh_centers_batch, s_grid
+                        0.5 * encoding_g_surf, surface_mesh_centers_batch, s_grid
                     )
                     pos_encoding = pos_surface_center_of_mass_batch
                     pos_encoding = model.module.position_encoder(
@@ -324,8 +324,6 @@ def main(cfg: DictConfig):
     DistributedManager.initialize()
     dist = DistributedManager()
 
-    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
     if model_type == "volume" or model_type == "combined":
         volume_variable_names = list(cfg.variables.volume.solution.keys())
         num_vol_vars = 0
@@ -370,21 +368,9 @@ def main(cfg: DictConfig):
 
     model = torch.compile(model, disable=True)
 
-    model_load_path = os.path.join(cfg.resume_dir, "best_model")
-    # retrive the smallest validation loss if available
-    numbers = []
-    for filename in os.listdir(model_load_path):
-        match = re.search(r"\d+\.\d*[1-9]\d*", filename)
-        if match:
-            number = float(match.group(0))
-            if number != 0.1:
-                numbers.append(number)
-
-    numbers.sort()
-    print(f"Best validation loss: {numbers[0]}")
     checkpoint = torch.load(
         to_absolute_path(
-            os.path.join(model_load_path, f"DoMINO.0.{str(numbers[0])}.pt")
+            os.path.join(cfg.resume_dir, cfg.eval.checkpoint_name)
         ),
         map_location=dist.device,
     )

--- a/examples/cfd/external_aerodynamics/domino/src/train.py
+++ b/examples/cfd/external_aerodynamics/domino/src/train.py
@@ -955,7 +955,7 @@ def main(cfg: DictConfig) -> None:
 
         train_sampler.set_epoch(epoch)
         val_sampler.set_epoch(epoch)
-        
+
         initial_integral_factor = initial_integral_factor_orig
 
         model.train(True)


### PR DESCRIPTION
# Modulus Pull Request

## Description
I have added a minimal retraining recipe and validated it with Luminary Cloud dataset we had generated for SC'24.  Also, the non-dimensionalization of flow variables is moved out of domino_datapipe.py to openfoam_datapipe.py so that users can have more control over the order and type of solution variables they can model.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->