### PR TITLE
Cleanup dependencies, pytests and unused imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhancements and bug fixes to DoMINO model and training example
 - Enhancement to parameterize DoMINO model with inlet velocity
 - Moved non-dimensionaliztion out of domino datapipe to datapipe in domino example
+- Updated utils in `modulus.launch.logging` to avoid unnecessary `wandb` and `mlflow` imports
 
 ### Deprecated
 
@@ -28,11 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update pytests to skip when the required dependencies are not present
+
 ### Security
 
 ### Dependencies
 
-- Remove the numpy dependency upper bound.
+- Remove the numpy dependency upper bound
+- Moved pytz and nvtx to optional
+- Update the base image for the Dockerfile
 
 ## [0.9.0] - 2024-12-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,15 @@ The pipeline has following stages:
     test, you will have to review your changes and fix the issues.
     To run pytest locally you can simply run `pytest` inside the `test` folder.
 
+    While writing these tests, we encourage you to make use of the
+    [`@nfs_data_or_fail`](https://github.com/NVIDIA/modulus/blob/main/test/pytest_utils.py#L92)
+    and the [`@import_of_fail`](https://github.com/NVIDIA/modulus/blob/main/test/pytest_utils.py#L25)
+    decorators to appropriately skip your tests for developers and users not having your
+    test specific datasets and dependencies respectively. The CI has these datasets and
+    dependencies so your tests will get executed during CI.
+    However, this mechanism helps us provide a better developer and user experience
+    when working with the unit tests.
+
 6. `doctest`
     Checks if the examples in the docstrings run and produce desired outputs.
     It is highly recommended that you provide simple examples of your functions/classes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ The pipeline has following stages:
     decorators to appropriately skip your tests for developers and users not having your
     test specific datasets and dependencies respectively. The CI has these datasets and
     dependencies so your tests will get executed during CI.
-    However, this mechanism helps us provide a better developer and user experience
+    This mechanism helps us provide a better developer and user experience
     when working with the unit tests.
 
 6. `doctest`

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:24.11-py3
+ARG BASE_CONTAINER=nvcr.io/nvidia/pytorch:25.01-py3
 FROM ${BASE_CONTAINER} as builder
 
 ARG TARGETPLATFORM

--- a/examples/cfd/darcy_transolver/train_transolver_darcy.py
+++ b/examples/cfd/darcy_transolver/train_transolver_darcy.py
@@ -27,7 +27,8 @@ from modulus.datapipes.benchmarks.darcy import Darcy2D
 from modulus.distributed import DistributedManager
 from modulus.utils import StaticCaptureTraining, StaticCaptureEvaluateNoGrad
 from modulus.launch.utils import load_checkpoint, save_checkpoint
-from modulus.launch.logging import PythonLogger, LaunchLogger, initialize_mlflow
+from modulus.launch.logging import PythonLogger, LaunchLogger
+from modulus.launch.logging.mlflow import initialize_mlflow
 
 from validator import GridValidator
 

--- a/examples/cfd/external_aerodynamics/xaeronet/surface/train.py
+++ b/examples/cfd/external_aerodynamics/xaeronet/surface/train.py
@@ -44,7 +44,7 @@ from torch.utils.tensorboard import SummaryWriter
 from omegaconf import DictConfig
 
 from modulus.distributed import DistributedManager
-from modulus.launch.logging import initialize_wandb
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.models.meshgraphnet import MeshGraphNet
 
 # Get the absolute path to the parent directory

--- a/examples/cfd/external_aerodynamics/xaeronet/volume/train.py
+++ b/examples/cfd/external_aerodynamics/xaeronet/volume/train.py
@@ -35,7 +35,7 @@ import torch
 import numpy as np
 import torch.optim as optim
 import matplotlib.pyplot as plt
-from modulus.launch.logging import initialize_wandb
+from modulus.launch.logging.wandb import initialize_wandb
 import json
 import wandb as wb
 import hydra

--- a/examples/cfd/lagrangian_mgn/train.py
+++ b/examples/cfd/lagrangian_mgn/train.py
@@ -33,8 +33,8 @@ from modulus.distributed.manager import DistributedManager
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.models.meshgraphnet import MeshGraphNet
 

--- a/examples/cfd/mhd_pino/train_mhd.py
+++ b/examples/cfd/mhd_pino/train_mhd.py
@@ -31,8 +31,8 @@ from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.launch.logging import (
     PythonLogger,
     LaunchLogger,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.sym.hydra import to_absolute_path
 
 from losses import LossMHD, LossMHD_Modulus

--- a/examples/cfd/mhd_pino/train_mhd_vec_pot.py
+++ b/examples/cfd/mhd_pino/train_mhd_vec_pot.py
@@ -31,8 +31,8 @@ from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.launch.logging import (
     PythonLogger,
     LaunchLogger,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.sym.hydra import to_absolute_path
 
 from losses import LossMHDVecPot, LossMHDVecPot_Modulus

--- a/examples/cfd/mhd_pino/train_mhd_vec_pot_tfno.py
+++ b/examples/cfd/mhd_pino/train_mhd_vec_pot_tfno.py
@@ -31,8 +31,8 @@ from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.launch.logging import (
     PythonLogger,
     LaunchLogger,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.sym.hydra import to_absolute_path
 
 from losses import LossMHDVecPot, LossMHDVecPot_Modulus

--- a/examples/cfd/stokes_mgn/pi_fine_tuning.py
+++ b/examples/cfd/stokes_mgn/pi_fine_tuning.py
@@ -43,8 +43,8 @@ from typing import Dict
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.models.mlp.fully_connected import FullyConnected
 from modulus.sym.eq.pde import PDE
 from modulus.sym.eq.phy_informer import PhysicsInformer

--- a/examples/cfd/stokes_mgn/pi_fine_tuning_gnn.py
+++ b/examples/cfd/stokes_mgn/pi_fine_tuning_gnn.py
@@ -43,8 +43,8 @@ from typing import Dict, Optional
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.models.meshgraphnet import MeshGraphNet
 from modulus.sym.eq.pde import PDE
 from modulus.sym.eq.phy_informer import PhysicsInformer

--- a/examples/cfd/stokes_mgn/train.py
+++ b/examples/cfd/stokes_mgn/train.py
@@ -36,8 +36,8 @@ from modulus.distributed.manager import DistributedManager
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.models.meshgraphnet import MeshGraphNet
 

--- a/examples/cfd/vortex_shedding_mesh_reduced/test_sequence.py
+++ b/examples/cfd/vortex_shedding_mesh_reduced/test_sequence.py
@@ -27,8 +27,8 @@ from modulus.distributed.manager import DistributedManager
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint
 from modulus.models.mesh_reduced.mesh_reduced import Mesh_Reduced
 from train_sequence import Sequence_Trainer

--- a/examples/cfd/vortex_shedding_mesh_reduced/train.py
+++ b/examples/cfd/vortex_shedding_mesh_reduced/train.py
@@ -32,8 +32,8 @@ from modulus.distributed.manager import DistributedManager
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.models.mesh_reduced.mesh_reduced import Mesh_Reduced
 

--- a/examples/cfd/vortex_shedding_mesh_reduced/train_sequence.py
+++ b/examples/cfd/vortex_shedding_mesh_reduced/train_sequence.py
@@ -33,8 +33,8 @@ from modulus.distributed.manager import DistributedManager
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.models.mesh_reduced.mesh_reduced import Mesh_Reduced
 from modulus.models.mesh_reduced.temporal_model import Sequence_Model

--- a/examples/cfd/vortex_shedding_mgn/train.py
+++ b/examples/cfd/vortex_shedding_mgn/train.py
@@ -33,8 +33,8 @@ from modulus.distributed.manager import DistributedManager
 from modulus.launch.logging import (
     PythonLogger,
     RankZeroLoggingWrapper,
-    initialize_wandb,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.models.meshgraphnet import MeshGraphNet
 

--- a/examples/healthcare/bloodflow_1d_mgn/train.py
+++ b/examples/healthcare/bloodflow_1d_mgn/train.py
@@ -31,9 +31,9 @@ from generate_dataset import Bloodflow1DDataset
 
 from modulus.launch.logging import (
     PythonLogger,
-    initialize_wandb,
     RankZeroLoggingWrapper,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 import json
 from omegaconf import DictConfig

--- a/examples/weather/graphcast/train_graphcast.py
+++ b/examples/weather/graphcast/train_graphcast.py
@@ -39,9 +39,9 @@ from modulus.utils.graphcast.loss import (
 )
 from modulus.launch.logging import (
     PythonLogger,
-    initialize_wandb,
     RankZeroLoggingWrapper,
 )
+from modulus.launch.logging.wandb import initialize_wandb
 from modulus.launch.utils import load_checkpoint, save_checkpoint
 
 from train_utils import count_trainable_params, prepare_input

--- a/modulus/launch/logging/__init__.py
+++ b/modulus/launch/logging/__init__.py
@@ -16,5 +16,4 @@
 
 from .console import PythonLogger, RankZeroLoggingWrapper
 from .launch import LaunchLogger
-from .mlflow import initialize_mlflow
 from .wandb import initialize_wandb

--- a/modulus/launch/logging/__init__.py
+++ b/modulus/launch/logging/__init__.py
@@ -16,4 +16,3 @@
 
 from .console import PythonLogger, RankZeroLoggingWrapper
 from .launch import LaunchLogger
-from .wandb import initialize_wandb

--- a/modulus/launch/logging/launch.py
+++ b/modulus/launch/logging/launch.py
@@ -23,12 +23,10 @@ from typing import Dict, Tuple, Union
 
 import torch
 import torch.cuda.profiler as profiler
-import wandb
 
 from modulus.distributed import DistributedManager, reduce_loss
 
 from .console import PythonLogger
-from .wandb import alert
 
 
 class LaunchLogger(object):
@@ -133,6 +131,8 @@ class LaunchLogger(object):
 
         # Set x axis metric to epoch for this namespace
         if self.wandb_backend:
+            import wandb
+
             wandb.define_metric(name_space + "/mini_batch_*", step_metric="iter")
             wandb.define_metric(name_space + "/*", step_metric="epoch")
 
@@ -284,6 +284,10 @@ class LaunchLogger(object):
             and self.epoch % self.epoch_alert_freq == 0
         ):
             if self.wandb_backend:
+                import wandb
+
+                from .wandb import alert
+
                 # TODO: Make this a little more informative?
                 alert(
                     title=f"{sys.argv[0]} training progress report",
@@ -321,6 +325,8 @@ class LaunchLogger(object):
 
         # WandB Logging
         if self.wandb_backend:
+            import wandb
+
             # For WandB send step in as a metric
             # Step argument in lod function does not work with multiple log calls at
             # different intervals
@@ -352,6 +358,8 @@ class LaunchLogger(object):
             return
 
         if self.wandb_backend:
+            import wandb
+
             wandb.log({artifact_file: figure})
 
         if self.mlflow_backend:
@@ -405,9 +413,12 @@ class LaunchLogger(object):
         use_mlflow : bool, optional
             Use MLFlow logging, by default False
         """
-        if wandb.run is None and use_wandb:
-            PythonLogger().warning("WandB not initialized, turning off")
-            use_wandb = False
+        if use_wandb:
+            import wandb
+
+            if wandb.run is None:
+                PythonLogger().warning("WandB not initialized, turning off")
+                use_wandb = False
 
         if use_wandb:
             LaunchLogger.toggle_wandb(True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,21 +12,19 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache 2.0"}
 dependencies = [
-    "torch>=2.0.0",
+    "certifi>=2023.7.22",
+    "fsspec>=2023.1.0",
     "numpy>=1.22.4",
+    "nvidia_dali_cuda120>=1.35.0",
+    "onnx>=1.14.0",
+    "s3fs>=2023.5.0",
+    "setuptools>=67.6.0",
+    "timm>=0.9.12",
+    "torch>=2.0.0",
+    "tqdm>=4.60.0",
+    "treelib>=1.2.5",
     "xarray>=2023.1.0",
     "zarr>=2.14.2",
-    "fsspec>=2023.1.0",
-    "s3fs>=2023.5.0",
-    "nvidia_dali_cuda120>=1.35.0",
-    "setuptools>=67.6.0",
-    "certifi>=2023.7.22",
-    "pytz>=2023.3",
-    "treelib>=1.2.5",
-    "tqdm>=4.60.0",
-    "nvtx>=0.2.8",
-    "onnx>=1.14.0",
-    "timm>=0.9.12",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -90,6 +88,8 @@ all = [
     "einops>=0.7.0",
     "pyspng>=0.1.0",
     "shapely>=2.0.6",
+    "pytz>=2023.3",
+    "nvtx>=0.2.8",
     "nvidia-modulus[launch]",
     "nvidia-modulus[dev]",
     "nvidia-modulus[makani]",
@@ -139,3 +139,4 @@ Fengwu = "modulus.models.fengwu:Fengwu"
 SwinRNN = "modulus.models.swinvrnn:SwinRNN"
 EDMPrecondSR = "modulus.models.diffusion:EDMPrecondSR"
 UNet = "modulus.models.diffusion:UNet"
+

--- a/test/datapipes/test_bsms.py
+++ b/test/datapipes/test_bsms.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dgl
 import pytest
 import torch
 from pytest_utils import import_or_fail
+
+dgl = pytest.importorskip("dgl")
 
 
 @pytest.fixture

--- a/test/datapipes/test_healpix.py
+++ b/test/datapipes/test_healpix.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 import xarray as xr
-from omegaconf import DictConfig
 from pytest_utils import nfsdata_or_fail
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
@@ -35,6 +34,8 @@ from modulus.datapipes.healpix.data_modules import (
 )
 from modulus.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
 from modulus.distributed import DistributedManager
+
+omegaconf = pytest.importorskip("omegaconf")
 
 
 @pytest.fixture
@@ -77,7 +78,7 @@ def scaling_dict():
         "tp6": {"mean": 1, "std": 0, "log_epsilon": 1e-6},
         "extra": {"mean": 1, "std": 0},
     }
-    return DictConfig(scaling)
+    return omegaconf.DictConfig(scaling)
 
 
 @pytest.fixture
@@ -95,7 +96,7 @@ def scaling_double_dict():
         "z": {"mean": 0, "std": 2},
         "extra": {"mean": 0, "std": 2},
     }
-    return DictConfig(scaling)
+    return omegaconf.DictConfig(scaling)
 
 
 @nfsdata_or_fail
@@ -213,7 +214,7 @@ def test_TimeSeriesDataset_initialization(
         )
 
     # check for failure of invalid scaling variable on input
-    invalid_scaling = DictConfig(
+    invalid_scaling = omegaconf.DictConfig(
         {
             "bogosity": {"mean": 0, "std": 42},
         }
@@ -513,7 +514,7 @@ def test_TimeSeriesDataModule_initialization(
         batch_size=1,
         prebuilt_dataset=True,
         scaling=scaling_double_dict,
-        splits=DictConfig(splits),
+        splits=omegaconf.DictConfig(splits),
     )
     assert isinstance(timeseries_dm, TimeSeriesDataModule)
     DistributedManager.cleanup()

--- a/test/datapipes/test_healpix.py
+++ b/test/datapipes/test_healpix.py
@@ -22,17 +22,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 import xarray as xr
-from pytest_utils import nfsdata_or_fail
+from pytest_utils import import_or_fail, nfsdata_or_fail
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
-from modulus.datapipes.healpix.data_modules import (
-    TimeSeriesDataModule,
-    create_time_series_dataset_classic,
-    open_time_series_dataset_classic_on_the_fly,
-    open_time_series_dataset_classic_prebuilt,
-)
-from modulus.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
 from modulus.distributed import DistributedManager
 
 omegaconf = pytest.importorskip("omegaconf")
@@ -99,8 +92,13 @@ def scaling_double_dict():
     return omegaconf.DictConfig(scaling)
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_open_time_series_on_the_fly(create_path, pytestconfig):
+    from modulus.datapipes.healpix.data_modules import (
+        open_time_series_dataset_classic_on_the_fly,
+    )
+
     variables = ["z500", "z1000"]
     constants = {"lsm": "lsm"}
 
@@ -119,9 +117,14 @@ def test_open_time_series_on_the_fly(create_path, pytestconfig):
     assert ds_var.equals(base[test_var])
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_open_time_series(data_dir, dataset_name, pytestconfig):
     # check for failure of non-existant dataset
+    from modulus.datapipes.healpix.data_modules import (
+        open_time_series_dataset_classic_prebuilt,
+    )
+
     with pytest.raises(FileNotFoundError, match=("Dataset doesn't appear to exist at")):
         open_time_series_dataset_classic_prebuilt("/null_path", dataset_name)
 
@@ -129,8 +132,14 @@ def test_open_time_series(data_dir, dataset_name, pytestconfig):
     assert isinstance(ds, xr.Dataset)
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
+
+    from modulus.datapipes.healpix.data_modules import (
+        create_time_series_dataset_classic,
+    )
+
     variables = ["z500", "z1000"]
     constants = {"lsm": "lsm"}
     scaling = {"z500": {"log_epsilon": 2}}
@@ -182,10 +191,14 @@ def test_create_time_series(data_dir, dataset_name, create_path, pytestconfig):
     delete_dataset(create_path, dataset_name)
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataset_initialization(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -273,10 +286,13 @@ def test_TimeSeriesDataset_initialization(
     assert isinstance(timeseries_ds, TimeSeriesDataset)
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataset_get_constants(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -295,8 +311,11 @@ def test_TimeSeriesDataset_get_constants(
     )
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataset_len(data_dir, dataset_name, scaling_dict, pytestconfig):
+    from modulus.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -334,10 +353,13 @@ def test_TimeSeriesDataset_len(data_dir, dataset_name, scaling_dict, pytestconfi
     assert len(timeseries_ds) == (len(zarr_ds.time.values) - 2) // 2
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataset_get(
     data_dir, dataset_name, scaling_double_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.timeseries_dataset import TimeSeriesDataset
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -439,10 +461,15 @@ def test_TimeSeriesDataset_get(
     assert len(inputs) == (len(timeseries_ds[0]) + 1)
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataModule_initialization(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.data_modules import (
+        TimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     splits = {
         "train_date_start": "1959-01-01",
@@ -520,10 +547,15 @@ def test_TimeSeriesDataModule_initialization(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataModule_get_constants(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.data_modules import (
+        TimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     constants = {"lsm": "lsm"}
 
@@ -592,10 +624,16 @@ def test_TimeSeriesDataModule_get_constants(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TimeSeriesDataModule_get_dataloaders(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.data_modules import (
+        TimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     splits = {
         "train_date_start": "1979-01-01",

--- a/test/datapipes/test_healpix_couple.py
+++ b/test/datapipes/test_healpix_couple.py
@@ -23,15 +23,10 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from pytest_utils import nfsdata_or_fail
+from pytest_utils import import_or_fail, nfsdata_or_fail
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
-from modulus.datapipes.healpix.coupledtimeseries_dataset import CoupledTimeSeriesDataset
-from modulus.datapipes.healpix.couplers import ConstantCoupler, TrailingAverageCoupler
-from modulus.datapipes.healpix.data_modules import (
-    CoupledTimeSeriesDataModule,
-)
 from modulus.distributed import DistributedManager
 
 omegaconf = pytest.importorskip("omegaconf")
@@ -96,8 +91,14 @@ def scaling_double_dict():
     return omegaconf.DictConfig(scaling)
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
+
+    from modulus.datapipes.healpix.couplers import (
+        ConstantCoupler,
+    )
+
     variables = ["z500", "z1000"]
     input_times = ["0h"]
     input_time_dim = 1
@@ -146,8 +147,14 @@ def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
+
+    from modulus.datapipes.healpix.couplers import (
+        TrailingAverageCoupler,
+    )
+
     variables = ["z500", "z1000"]
     input_times = ["6h", "12h"]
     input_time_dim = 2
@@ -204,10 +211,16 @@ def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconf
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_initialization(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.coupledtimeseries_dataset import (
+        CoupledTimeSeriesDataset,
+    )
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -352,10 +365,16 @@ def test_CoupledTimeSeriesDataset_initialization(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_get_constants(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.coupledtimeseries_dataset import (
+        CoupledTimeSeriesDataset,
+    )
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -394,10 +413,15 @@ def test_CoupledTimeSeriesDataset_get_constants(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_len(
     data_dir, dataset_name, scaling_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.coupledtimeseries_dataset import (
+        CoupledTimeSeriesDataset,
+    )
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -474,10 +498,15 @@ def test_CoupledTimeSeriesDataset_len(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataset_get(
     data_dir, dataset_name, scaling_double_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.coupledtimeseries_dataset import (
+        CoupledTimeSeriesDataset,
+    )
+
     # open our test dataset
     ds_path = Path(data_dir, dataset_name + ".zarr")
     zarr_ds = xr.open_zarr(ds_path)
@@ -609,10 +638,16 @@ def test_CoupledTimeSeriesDataset_get(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_initialization(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.data_modules import (
+        CoupledTimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     splits = {
         "train_date_start": "1959-01-01",
@@ -710,10 +745,16 @@ def test_CoupledTimeSeriesDataModule_initialization(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_get_constants(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.data_modules import (
+        CoupledTimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     constants = {"lsm": "lsm"}
 
@@ -800,10 +841,16 @@ def test_CoupledTimeSeriesDataModule_get_constants(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_get_dataloaders(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+
+    from modulus.datapipes.healpix.data_modules import (
+        CoupledTimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     splits = {
         "train_date_start": "1979-01-01",
@@ -872,10 +919,15 @@ def test_CoupledTimeSeriesDataModule_get_dataloaders(
     DistributedManager.cleanup()
 
 
+@import_or_fail("omegaconf")
 @nfsdata_or_fail
 def test_CoupledTimeSeriesDataModule_get_coupled_vars(
     data_dir, create_path, dataset_name, scaling_double_dict, pytestconfig
 ):
+    from modulus.datapipes.healpix.data_modules import (
+        CoupledTimeSeriesDataModule,
+    )
+
     variables = ["z500", "z1000"]
     constant_coupler = [
         {

--- a/test/datapipes/test_lagrangian.py
+++ b/test/datapipes/test_lagrangian.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dgl
 import pytest
 import torch
 from pytest_utils import import_or_fail, nfsdata_or_fail
 
 from . import common
+
+dgl = pytest.importorskip("dgl")
+
 
 Tensor = torch.Tensor
 

--- a/test/datapipes/test_mesh_datapipe.py
+++ b/test/datapipes/test_mesh_datapipe.py
@@ -29,7 +29,7 @@ def cgns_data_dir():
     return path
 
 
-@import_or_fail("vtk", "warp")
+@import_or_fail(["vtk", "warp"])
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
 def test_mesh_datapipe(device, tmp_path, pytestconfig):
     """Tests the MeshDatapipe class with VTP and VTU files."""

--- a/test/datapipes/test_mesh_datapipe.py
+++ b/test/datapipes/test_mesh_datapipe.py
@@ -21,7 +21,6 @@ import pytest
 from pytest_utils import import_or_fail
 
 # from pytest_utils import nfsdata_or_fail
-from modulus.datapipes.cae import MeshDatapipe
 
 
 @pytest.fixture
@@ -30,12 +29,14 @@ def cgns_data_dir():
     return path
 
 
-@import_or_fail(["vtk"])
+@import_or_fail("vtk", "warp")
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
 def test_mesh_datapipe(device, tmp_path, pytestconfig):
     """Tests the MeshDatapipe class with VTP and VTU files."""
 
     import vtk
+
+    from modulus.datapipes.cae import MeshDatapipe
 
     def _create_random_vtp_vtu_mesh(
         num_points: int, num_triangles: int, dir: str

--- a/test/datapipes/test_synthetic.py
+++ b/test/datapipes/test_synthetic.py
@@ -16,15 +16,17 @@
 
 
 import pytest
-
-from modulus.datapipes.climate import (
-    SyntheticWeatherDataLoader,
-    SyntheticWeatherDataset,
-)
+from pytest_utils import import_or_fail
 
 
+@import_or_fail("h5py")
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
-def test_dataloader_setup(device):
+def test_dataloader_setup(device, pytestconfig):
+    from modulus.datapipes.climate import (
+        SyntheticWeatherDataLoader,
+        SyntheticWeatherDataset,
+    )
+
     dataloader = SyntheticWeatherDataLoader(
         channels=[0, 1, 2, 3],
         num_samples_per_year=12,
@@ -41,9 +43,15 @@ def test_dataloader_setup(device):
     assert isinstance(dataloader.dataset, SyntheticWeatherDataset)
 
 
+@import_or_fail("h5py")
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
-def test_dataloader_iteration(device):
+def test_dataloader_iteration(device, pytestconfig):
     """Test the iteration over batches in the DataLoader."""
+
+    from modulus.datapipes.climate import (
+        SyntheticWeatherDataLoader,
+    )
+
     dataloader = SyntheticWeatherDataLoader(
         channels=[0, 1],
         num_samples_per_year=30,
@@ -66,9 +74,15 @@ def test_dataloader_iteration(device):
         break  # Only test one batch for quick testing
 
 
+@import_or_fail("h5py")
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
-def test_dataloader_length(device):
+def test_dataloader_length(device, pytestconfig):
     """Test the length of the DataLoader to ensure it is correct based on the dataset and batch size."""
+
+    from modulus.datapipes.climate import (
+        SyntheticWeatherDataLoader,
+    )
+
     dataloader = SyntheticWeatherDataLoader(
         channels=[0, 1, 2],
         num_samples_per_year=30,

--- a/test/metrics/test_metrics_cfd.py
+++ b/test/metrics/test_metrics_cfd.py
@@ -16,7 +16,6 @@
 
 import numpy as np
 import pytest
-import pyvista as pv
 import torch
 from pytest_utils import import_or_fail
 
@@ -26,6 +25,8 @@ from modulus.metrics.cae.cfd import (
     compute_tke_spectrum,
     dominant_freq_calc,
 )
+
+pv = pytest.importorskip("pyvista")
 
 
 @pytest.fixture

--- a/test/metrics/test_metrics_integral.py
+++ b/test/metrics/test_metrics_integral.py
@@ -16,10 +16,11 @@
 
 import numpy as np
 import pytest
-import pyvista as pv
 from pytest_utils import import_or_fail
 
 from modulus.metrics.cae.integral import line_integral, surface_integral
+
+pv = pytest.importorskip("pyvista")
 
 
 @pytest.fixture

--- a/test/models/diffusion/test_preconditioning.py
+++ b/test/models/diffusion/test_preconditioning.py
@@ -16,8 +16,8 @@
 
 import pytest
 import torch
+from pytest_utils import import_or_fail
 
-from modulus.launch.utils import load_checkpoint, save_checkpoint
 from modulus.models.diffusion.preconditioning import (
     EDMPrecond,
     EDMPrecondSR,
@@ -58,7 +58,11 @@ def test_EDMPrecondSR_forward(scale_cond_input):
     assert output.shape == (b, c_target, x, y)
 
 
-def test_EDMPrecondSR_serialization(tmp_path):
+@import_or_fail("termcolor")
+def test_EDMPrecondSR_serialization(tmp_path, pytestconfig):
+
+    from modulus.launch.utils import load_checkpoint, save_checkpoint
+
     module = EDMPrecondSR(8, 1, 1, 1, scale_cond_input=False)
     model_path = tmp_path / "output.mdlus"
     module.save(model_path.as_posix())

--- a/test/models/dlwp_healpix/test_healpix_blocks.py
+++ b/test/models/dlwp_healpix/test_healpix_blocks.py
@@ -23,18 +23,7 @@ sys.path.append(os.path.join(os.path.dirname(script_path), ".."))
 import common
 import pytest
 import torch
-
-from modulus.models.dlwp_healpix_layers import (
-    AvgPool,
-    BasicConvBlock,
-    ConvGRUBlock,
-    ConvNeXtBlock,
-    DoubleConvNeXtBlock,
-    Interpolate,
-    MaxPool,
-    SymmetricConvNeXtBlock,
-    TransposedConvUpsample,  #
-)
+from pytest_utils import import_or_fail
 
 
 @pytest.fixture
@@ -50,15 +39,27 @@ def test_data():
     return generate_test_data
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_ConvGRUBlock_initialization(device, test_data):
+def test_ConvGRUBlock_initialization(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvGRUBlock,
+    )
+
     in_channels = 2
     conv_gru_func = ConvGRUBlock(in_channels=in_channels).to(device)
     assert isinstance(conv_gru_func, ConvGRUBlock)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_ConvGRUBlock_forward(device, test_data):
+def test_ConvGRUBlock_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvGRUBlock,
+    )
+
     in_channels = 2
     tensor_size = 16
     conv_gru_func = ConvGRUBlock(in_channels=in_channels).to(device)
@@ -75,8 +76,14 @@ def test_ConvGRUBlock_forward(device, test_data):
     assert not common.compare_output(outvar_hist, outvar)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_ConvNeXtBlock_initialization(device):
+def test_ConvNeXtBlock_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvNeXtBlock,
+    )
+
     in_channels = 2
     convnext_block = ConvNeXtBlock(in_channels=in_channels).to(device)
     assert isinstance(convnext_block, ConvNeXtBlock)
@@ -91,8 +98,14 @@ def test_ConvNeXtBlock_initialization(device):
     assert isinstance(convnext_block, ConvNeXtBlock)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_ConvNeXtBlock_forward(device, test_data):
+def test_ConvNeXtBlock_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvNeXtBlock,
+    )
+
     in_channels = 2
     out_channels = 1
     tensor_size = 16
@@ -114,8 +127,14 @@ def test_ConvNeXtBlock_forward(device, test_data):
     assert outvar.shape == out_shape
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_DoubleConvNeXtBlock_initialization(device):
+def test_DoubleConvNeXtBlock_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        DoubleConvNeXtBlock,
+    )
+
     in_channels = 2
     out_channels = 1
     latent_channels = 1
@@ -136,8 +155,14 @@ def test_DoubleConvNeXtBlock_initialization(device):
     assert isinstance(doubleconvnextblock, DoubleConvNeXtBlock)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_DoubleConvNeXtBlock_forward(device, test_data):
+def test_DoubleConvNeXtBlock_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        DoubleConvNeXtBlock,
+    )
+
     in_channels = 2
     out_channels = 1
     latent_channels = 1
@@ -166,8 +191,14 @@ def test_DoubleConvNeXtBlock_forward(device, test_data):
     assert outvar.shape == out_shape
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_SymmetricConvNeXtBlock_initialization(device):
+def test_SymmetricConvNeXtBlock_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        SymmetricConvNeXtBlock,
+    )
+
     in_channels = 2
     latent_channels = 1
     symmetric_convnextblock = SymmetricConvNeXtBlock(
@@ -185,8 +216,14 @@ def test_SymmetricConvNeXtBlock_initialization(device):
     assert isinstance(symmetric_convnextblock, SymmetricConvNeXtBlock)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_SymmetricConvNeXtBlock_forward(device, test_data):
+def test_SymmetricConvNeXtBlock_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        SymmetricConvNeXtBlock,
+    )
+
     in_channels = 2
     latent_channels = 1
     tensor_size = 16
@@ -207,8 +244,14 @@ def test_SymmetricConvNeXtBlock_forward(device, test_data):
     assert outvar.shape == out_shape
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_BasicConvBlock_initialization(device):
+def test_BasicConvBlock_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        BasicConvBlock,
+    )
+
     in_channels = 3
     out_channels = 1
     latent_channels = 2
@@ -228,8 +271,14 @@ def test_BasicConvBlock_initialization(device):
     assert isinstance(conv_block, BasicConvBlock)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_BasicConvBlock_forward(device, test_data):
+def test_BasicConvBlock_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        BasicConvBlock,
+    )
+
     in_channels = 3
     out_channels = 1
     tensor_size = 16
@@ -248,15 +297,26 @@ def test_BasicConvBlock_forward(device, test_data):
     assert outvar.shape == out_shape
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_MaxPool_initialization(device):
+def test_MaxPool_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        MaxPool,
+    )
+
     pooling = 2
     maxpool_block = MaxPool(pooling=pooling).to(device)
     assert isinstance(maxpool_block, MaxPool)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_MaxPool_forward(device, test_data):
+def test_MaxPool_forward(device, test_data, pytestconfig):
+    from modulus.models.dlwp_healpix_layers import (
+        MaxPool,
+    )
+
     pooling = 2
     size = 16
     channels = 4
@@ -270,15 +330,27 @@ def test_MaxPool_forward(device, test_data):
     assert common.compare_output(outvar, maxpool_block(invar))
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_AvgPool_initialization(device):
+def test_AvgPool_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        AvgPool,
+    )
+
     pooling = 2
     avgpool_block = AvgPool(pooling=pooling).to(device)
     assert isinstance(avgpool_block, AvgPool)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_AvgPool_forward(device, test_data):
+def test_AvgPool_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        AvgPool,
+    )
+
     pooling = 2
     size = 32
     channels = 4
@@ -295,8 +367,13 @@ def test_AvgPool_forward(device, test_data):
     assert common.compare_output(outvar, avgpool_block(invar))
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_TransposedConvUpsample_initialization(device):
+def test_TransposedConvUpsample_initialization(device, pytestconfig):
+    from modulus.models.dlwp_healpix_layers import (
+        TransposedConvUpsample,  #
+    )
+
     transposed_conv_upsample_block = TransposedConvUpsample().to(device)
     assert isinstance(transposed_conv_upsample_block, TransposedConvUpsample)
 
@@ -306,8 +383,14 @@ def test_TransposedConvUpsample_initialization(device):
     assert isinstance(transposed_conv_upsample_block, TransposedConvUpsample)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_TransposedConvUpsample_forward(device, test_data):
+def test_TransposedConvUpsample_forward(device, test_data, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        TransposedConvUpsample,
+    )
+
     in_channels = 2
     out_channels = 1
     size = 16
@@ -332,16 +415,27 @@ def test_TransposedConvUpsample_forward(device, test_data):
     assert outvar.shape == outsize
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_Interpolate_initialization(device):
+def test_Interpolate_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        Interpolate,
+    )
+
     scale = 2
     mode = "linear"
     interpolation_block = Interpolate(scale_factor=scale, mode=mode).to(device)
     assert isinstance(interpolation_block, Interpolate)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_Interpolate_forward(device):
+def test_Interpolate_forward(device, pytestconfig):
+    from modulus.models.dlwp_healpix_layers import (
+        Interpolate,
+    )
+
     scale = 2
     mode = "linear"
     interpolation_block = Interpolate(scale_factor=scale, mode=mode).to(device)

--- a/test/models/dlwp_healpix/test_healpix_encoder_decoder.py
+++ b/test/models/dlwp_healpix/test_healpix_encoder_decoder.py
@@ -23,20 +23,19 @@ sys.path.append(os.path.join(os.path.dirname(script_path), ".."))
 import common
 import pytest
 import torch
-
-from modulus.models.dlwp_healpix_layers import (
-    BasicConvBlock,  # for the output layer
-    ConvGRUBlock,  # for the recurrent layer
-    ConvNeXtBlock,  # for convolutional layer
-    MaxPool,  # for downsampling
-    TransposedConvUpsample,  # for upsampling
-    UNetDecoder,
-    UNetEncoder,
-)
+from pytest_utils import import_or_fail
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_UNetEncoder_initialize(device):
+def test_UNetEncoder_initialize(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvNeXtBlock,  # for convolutional layer
+        MaxPool,  # for downsampling
+        UNetEncoder,
+    )
+
     channels = 2
     n_channels = (16, 32, 64)
 
@@ -72,8 +71,16 @@ def test_UNetEncoder_initialize(device):
     torch.cuda.empty_cache()
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_UNetEncoder_forward(device):
+def test_UNetEncoder_forward(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvNeXtBlock,  # for convolutional layer
+        MaxPool,  # for downsampling
+        UNetEncoder,
+    )
+
     channels = 2
     hw_size = 16
     b_size = 12
@@ -114,8 +121,16 @@ def test_UNetEncoder_forward(device):
     torch.cuda.empty_cache()
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_UNetEncoder_reset(device):
+def test_UNetEncoder_reset(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        ConvNeXtBlock,  # for convolutional layer
+        MaxPool,  # for downsampling
+        UNetEncoder,
+    )
+
     channels = 2
     n_channels = (16, 32, 64)
 
@@ -144,8 +159,18 @@ def test_UNetEncoder_reset(device):
     torch.cuda.empty_cache()
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_UNetDecoder_initilization(device):
+def test_UNetDecoder_initilization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        BasicConvBlock,  # for the output layer
+        ConvGRUBlock,  # for the recurrent layer
+        ConvNeXtBlock,  # for convolutional layer
+        TransposedConvUpsample,  # for upsampling
+        UNetDecoder,
+    )
+
     in_channels = 2
     out_channels = 1
     n_channels = (64, 32, 16)
@@ -203,8 +228,18 @@ def test_UNetDecoder_initilization(device):
     torch.cuda.empty_cache()
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_UNetDecoder_forward(device):
+def test_UNetDecoder_forward(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        BasicConvBlock,  # for the output layer
+        ConvGRUBlock,  # for the recurrent layer
+        ConvNeXtBlock,  # for convolutional layer
+        TransposedConvUpsample,  # for upsampling
+        UNetDecoder,
+    )
+
     in_channels = 2
     out_channels = 1
     hw_size = 32
@@ -281,8 +316,18 @@ def test_UNetDecoder_forward(device):
     torch.cuda.empty_cache()
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_UNetDecoder_reset(device):
+def test_UNetDecoder_reset(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        BasicConvBlock,  # for the output layer
+        ConvGRUBlock,  # for the recurrent layer
+        ConvNeXtBlock,  # for convolutional layer
+        TransposedConvUpsample,  # for upsampling
+        UNetDecoder,
+    )
+
     in_channels = 2
     out_channels = 1
     hw_size = 32

--- a/test/models/dlwp_healpix/test_healpix_layers.py
+++ b/test/models/dlwp_healpix/test_healpix_layers.py
@@ -24,13 +24,7 @@ import common
 import numpy as np
 import pytest
 import torch
-
-from modulus.models.dlwp_healpix_layers import (
-    HEALPixFoldFaces,
-    HEALPixLayer,
-    HEALPixPadding,
-    HEALPixUnfoldFaces,
-)
+from pytest_utils import import_or_fail
 
 
 class MulX(torch.nn.Module):
@@ -44,14 +38,26 @@ class MulX(torch.nn.Module):
         return x * self.multiplier
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_HEALPixFoldFaces_initialization(device):
+def test_HEALPixFoldFaces_initialization(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixFoldFaces,
+    )
+
     fold_func = HEALPixFoldFaces()
     assert isinstance(fold_func, HEALPixFoldFaces)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_HEALPixFoldFaces_forward(device):
+def test_HEALPixFoldFaces_forward(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixFoldFaces,
+    )
+
     fold_func = HEALPixFoldFaces()
 
     tensor_size = torch.randint(low=2, high=4, size=(5,)).tolist()
@@ -66,14 +72,25 @@ def test_HEALPixFoldFaces_forward(device):
     assert fold_func(invar).stride() != outvar.stride()
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_HEALPixUnfoldFaces_initialization(device):
+def test_HEALPixUnfoldFaces_initialization(device, pytestconfig):
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixUnfoldFaces,
+    )
+
     unfold_func = HEALPixUnfoldFaces()
     assert isinstance(unfold_func, HEALPixUnfoldFaces)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_HEALPixUnfoldFaces_forward(device):
+def test_HEALPixUnfoldFaces_forward(device, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixUnfoldFaces,
+    )
+
     num_faces = 12
     unfold_func = HEALPixUnfoldFaces()
 
@@ -98,14 +115,26 @@ HEALPixPadding_testdata = [
 ]
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device,padding", HEALPixPadding_testdata)
-def test_HEALPixPadding_initialization(device, padding):
+def test_HEALPixPadding_initialization(device, padding, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixPadding,
+    )
+
     pad_func = HEALPixPadding(padding)
     assert isinstance(pad_func, HEALPixPadding)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device,padding", HEALPixPadding_testdata)
-def test_HEALPixPadding_forward(device, padding):
+def test_HEALPixPadding_forward(device, padding, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixPadding,
+    )
+
     num_faces = 12  # standard for healpix
     batch_size = 2
     pad_func = HEALPixPadding(padding)
@@ -144,14 +173,25 @@ HEALPixLayer_testdata = [
 ]
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device,multiplier", HEALPixLayer_testdata)
-def test_HEALPixLayer_initialization(device, multiplier):
+def test_HEALPixLayer_initialization(device, multiplier, pytestconfig):
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixLayer,
+    )
+
     layer = HEALPixLayer(layer=MulX, multiplier=multiplier)
     assert isinstance(layer, HEALPixLayer)
 
 
+@import_or_fail("hydra")
 @pytest.mark.parametrize("device,multiplier", HEALPixLayer_testdata)
-def test_HEALPixLayer_forward(device, multiplier):
+def test_HEALPixLayer_forward(device, multiplier, pytestconfig):
+
+    from modulus.models.dlwp_healpix_layers import (
+        HEALPixLayer,
+    )
+
     layer = HEALPixLayer(layer=MulX, multiplier=multiplier)
 
     kernel_size = 3

--- a/test/models/meshgraphnet/test_bsms_mgn.py
+++ b/test/models/meshgraphnet/test_bsms_mgn.py
@@ -14,13 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dgl
 import pytest
 import torch
 from models.common import validate_forward_accuracy
 from pytest_utils import import_or_fail
 
-from modulus.models.meshgraphnet.bsms_mgn import BiStrideMeshGraphNet
+dgl = pytest.importorskip("dgl")
 
 
 @pytest.fixture
@@ -29,10 +28,11 @@ def ahmed_data_dir():
     return path
 
 
-@import_or_fail("sparse_dot_mkl")
+@import_or_fail("sparse_dot_mkl", "dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_bsms_mgn_forward(pytestconfig, device):
     from modulus.datapipes.gnn.bsms import BistrideMultiLayerGraphDataset
+    from modulus.models.meshgraphnet.bsms_mgn import BiStrideMeshGraphNet
 
     torch.manual_seed(1)
 
@@ -89,10 +89,11 @@ def test_bsms_mgn_forward(pytestconfig, device):
     )
 
 
-@import_or_fail("sparse_dot_mkl")
+@import_or_fail("sparse_dot_mkl", "dgl")
 def test_bsms_mgn_ahmed(pytestconfig, ahmed_data_dir):
     from modulus.datapipes.gnn.ahmed_body_dataset import AhmedBodyDataset
     from modulus.datapipes.gnn.bsms import BistrideMultiLayerGraphDataset
+    from modulus.models.meshgraphnet.bsms_mgn import BiStrideMeshGraphNet
 
     device = torch.device("cuda:0")
 

--- a/test/models/meshgraphnet/test_bsms_mgn.py
+++ b/test/models/meshgraphnet/test_bsms_mgn.py
@@ -17,7 +17,7 @@
 import pytest
 import torch
 from models.common import validate_forward_accuracy
-from pytest_utils import import_or_fail
+from pytest_utils import import_or_fail, nfsdata_or_fail
 
 dgl = pytest.importorskip("dgl")
 
@@ -28,7 +28,7 @@ def ahmed_data_dir():
     return path
 
 
-@import_or_fail("sparse_dot_mkl", "dgl")
+@import_or_fail(["sparse_dot_mkl", "dgl"])
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_bsms_mgn_forward(pytestconfig, device):
     from modulus.datapipes.gnn.bsms import BistrideMultiLayerGraphDataset
@@ -89,7 +89,8 @@ def test_bsms_mgn_forward(pytestconfig, device):
     )
 
 
-@import_or_fail("sparse_dot_mkl", "dgl")
+@nfsdata_or_fail
+@import_or_fail(["sparse_dot_mkl", "dgl"])
 def test_bsms_mgn_ahmed(pytestconfig, ahmed_data_dir):
     from modulus.datapipes.gnn.ahmed_body_dataset import AhmedBodyDataset
     from modulus.datapipes.gnn.bsms import BistrideMultiLayerGraphDataset

--- a/test/models/meshgraphnet/test_meshgraphnet_snmg.py
+++ b/test/models/meshgraphnet/test_meshgraphnet_snmg.py
@@ -27,16 +27,16 @@ from meshgraphnet.utils import get_random_graph
 from pytest_utils import import_or_fail
 
 from modulus.distributed import DistributedManager, mark_module_as_shared
-from modulus.models.gnn_layers import (
-    partition_graph_by_coordinate_bbox,
-    partition_graph_nodewise,
-    partition_graph_with_id_mapping,
-)
 
 torch.backends.cuda.matmul.allow_tf32 = False
 
 
 def run_test_distributed_meshgraphnet(rank, world_size, dtype, partition_scheme):
+    from modulus.models.gnn_layers import (
+        partition_graph_by_coordinate_bbox,
+        partition_graph_nodewise,
+        partition_graph_with_id_mapping,
+    )
     from modulus.models.gnn_layers.utils import CuGraphCSC
     from modulus.models.meshgraphnet.meshgraphnet import MeshGraphNet
 

--- a/test/models/test_distributed_graph.py
+++ b/test/models/test_distributed_graph.py
@@ -18,13 +18,9 @@ import os
 
 import pytest
 import torch
+from pytest_utils import import_or_fail
 
 from modulus.distributed import DistributedManager
-from modulus.models.gnn_layers import (
-    DistributedGraph,
-    partition_graph_by_coordinate_bbox,
-)
-from modulus.models.graphcast.graph_cast_net import get_lat_lon_partition_separators
 
 
 def get_random_graph(device):
@@ -131,6 +127,13 @@ def run_test_distributed_graph(
     partition_scheme: str,
     use_torchrun: bool = False,
 ):
+
+    from modulus.models.gnn_layers import (
+        DistributedGraph,
+        partition_graph_by_coordinate_bbox,
+    )
+    from modulus.models.graphcast.graph_cast_net import get_lat_lon_partition_separators
+
     if not use_torchrun:
         os.environ["RANK"] = f"{rank}"
         os.environ["WORLD_SIZE"] = f"{world_size}"
@@ -338,9 +341,11 @@ def run_test_distributed_graph(
         del os.environ["MASTER_PORT"]
 
 
+@import_or_fail("dgl")
 @pytest.mark.multigpu
 @pytest.mark.parametrize("partition_scheme", ["lat_lon_bbox", "default"])
-def test_distributed_graph(partition_scheme):
+def test_distributed_graph(partition_scheme, pytestconfig):
+
     num_gpus = torch.cuda.device_count()
     assert num_gpus >= 2, "Not enough GPUs available for test"
     world_size = 2  # num_gpus
@@ -360,6 +365,7 @@ def test_distributed_graph(partition_scheme):
 
 
 if __name__ == "__main__":
+
     # to be launched with torchrun
     DistributedManager.initialize()
     run_test_distributed_graph(-1, -1, "lat_lon_bbox", True)

--- a/test/models/test_domino.py
+++ b/test/models/test_domino.py
@@ -20,8 +20,7 @@ from typing import Sequence
 
 import pytest
 import torch
-
-from modulus.models.domino.model import DoMINO
+from pytest_utils import import_or_fail
 
 # from . import common
 from .common.fwdaccuracy import save_output
@@ -58,9 +57,13 @@ def validate_domino(
         return compare_output(output, output_target, rtol, atol)
 
 
+@import_or_fail("warp")
 @pytest.mark.parametrize("device", ["cuda:0"])
-def test_domino_forward(device):
+def test_domino_forward(device, pytestconfig):
     """Test domino forward pass"""
+
+    from modulus.models.domino.model import DoMINO
+
     torch.manual_seed(0)
 
     @dataclass

--- a/test/models/test_graph_partition.py
+++ b/test/models/test_graph_partition.py
@@ -16,13 +16,7 @@
 
 import pytest
 import torch
-
-from modulus.models.gnn_layers import (
-    GraphPartition,
-    partition_graph_by_coordinate_bbox,
-    partition_graph_nodewise,
-    partition_graph_with_id_mapping,
-)
+from pytest_utils import import_or_fail
 
 
 @pytest.fixture
@@ -88,8 +82,15 @@ def assert_partitions_are_equal(a, b):
             assert torch.allclose(val_a, val_b), error_msg
 
 
+@import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_gp_mapping(global_graph, device):
+def test_gp_mapping(global_graph, device, pytestconfig):
+
+    from modulus.models.gnn_layers import (
+        GraphPartition,
+        partition_graph_with_id_mapping,
+    )
+
     offsets, indices, num_src_nodes, num_dst_nodes = global_graph
     partition_size = 4
     partition_rank = 0
@@ -134,8 +135,15 @@ def test_gp_mapping(global_graph, device):
     assert_partitions_are_equal(pg, pg_expected)
 
 
+@import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_gp_nodewise(global_graph, device):
+def test_gp_nodewise(global_graph, device, pytestconfig):
+
+    from modulus.models.gnn_layers import (
+        GraphPartition,
+        partition_graph_nodewise,
+    )
+
     offsets, indices, num_src_nodes, num_dst_nodes = global_graph
     partition_size = 4
     partition_rank = 0
@@ -175,8 +183,15 @@ def test_gp_nodewise(global_graph, device):
     assert_partitions_are_equal(pg, pg_expected)
 
 
+@import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_gp_matrixdecomp(global_graph_square, device):
+def test_gp_matrixdecomp(global_graph_square, device, pytestconfig):
+
+    from modulus.models.gnn_layers import (
+        GraphPartition,
+        partition_graph_nodewise,
+    )
+
     offsets, indices, num_src_nodes, num_dst_nodes = global_graph_square
     partition_size = 4
     partition_rank = 0
@@ -212,8 +227,15 @@ def test_gp_matrixdecomp(global_graph_square, device):
     assert_partitions_are_equal(pg, pg_expected)
 
 
+@import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_gp_coordinate_bbox(global_graph, device):
+def test_gp_coordinate_bbox(global_graph, device, pytestconfig):
+
+    from modulus.models.gnn_layers import (
+        GraphPartition,
+        partition_graph_by_coordinate_bbox,
+    )
+
     offsets, indices, num_src_nodes, num_dst_nodes = global_graph
     partition_size = 4
     partition_rank = 0
@@ -279,8 +301,15 @@ def test_gp_coordinate_bbox(global_graph, device):
     assert_partitions_are_equal(pg, pg_expected)
 
 
+@import_or_fail("dgl")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_gp_coordinate_bbox_lat_long(global_graph, device):
+def test_gp_coordinate_bbox_lat_long(global_graph, device, pytestconfig):
+
+    from modulus.models.gnn_layers import (
+        GraphPartition,
+        partition_graph_by_coordinate_bbox,
+    )
+
     offsets, indices, num_src_nodes, num_dst_nodes = global_graph
     src_lat = torch.FloatTensor([-75, -60, -45, -30, 30, 45, 60, 75]).view(-1, 1)
     dst_lat = torch.FloatTensor([-60, -30, 30, 30]).view(-1, 1)

--- a/test/utils/corrdiff/test_generation_steps.py
+++ b/test/utils/corrdiff/test_generation_steps.py
@@ -18,14 +18,16 @@ from functools import partial
 
 import pytest
 import torch
-
-from modulus.models.diffusion import EDMPrecondSR, UNet
-from modulus.utils.corrdiff import diffusion_step, regression_step
-from modulus.utils.generative import deterministic_sampler, stochastic_sampler
+from pytest_utils import import_or_fail
 
 
+@import_or_fail("cftime")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_regression_step(device):
+def test_regression_step(device, pytestconfig):
+
+    from modulus.models.diffusion import UNet
+    from modulus.utils.corrdiff import regression_step
+
     # define the net
     mock_unet = UNet(
         img_channels=2,
@@ -47,8 +49,14 @@ def test_regression_step(device):
     assert output.shape == (2, 2, 16, 16), "Output shape mismatch"
 
 
+@import_or_fail("cftime")
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
-def test_diffusion_step(device):
+def test_diffusion_step(device, pytestconfig):
+
+    from modulus.models.diffusion import EDMPrecondSR
+    from modulus.utils.corrdiff import diffusion_step
+    from modulus.utils.generative import deterministic_sampler, stochastic_sampler
+
     # Define the preconditioner
     mock_precond = EDMPrecondSR(
         img_resolution=[16, 16],

--- a/test/utils/corrdiff/test_netcdf_writer.py
+++ b/test/utils/corrdiff/test_netcdf_writer.py
@@ -20,8 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-
-from modulus.utils.corrdiff import NetCDFWriter
+from pytest_utils import import_or_fail
 
 
 @pytest.fixture
@@ -43,7 +42,11 @@ def mock_ncfile():
     return mock_file
 
 
-def test_init(mock_ncfile):
+@import_or_fail("cftime")
+def test_init(mock_ncfile, pytestconfig):
+
+    from modulus.utils.corrdiff import NetCDFWriter
+
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
     lon = np.array([[5.0, 6.0], [7.0, 8.0]])
     input_channels = []
@@ -86,7 +89,11 @@ def test_init(mock_ncfile):
     )
 
 
-def test_write_input(mock_ncfile):
+@import_or_fail("cftime")
+def test_write_input(mock_ncfile, pytestconfig):
+
+    from modulus.utils.corrdiff import NetCDFWriter
+
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
     lon = np.array([[5.0, 6.0], [7.0, 8.0]])
     input_channels = []
@@ -106,7 +113,11 @@ def test_write_input(mock_ncfile):
     mock_ncfile["input"][channel_name].__setitem__.assert_called_with(time_index, val)
 
 
-def test_write_truth(mock_ncfile):
+@import_or_fail("cftime")
+def test_write_truth(mock_ncfile, pytestconfig):
+
+    from modulus.utils.corrdiff import NetCDFWriter
+
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
     lon = np.array([[5.0, 6.0], [7.0, 8.0]])
     input_channels = []
@@ -126,7 +137,11 @@ def test_write_truth(mock_ncfile):
     mock_ncfile["truth"][channel_name].__setitem__.assert_called_with(time_index, val)
 
 
-def test_write_prediction(mock_ncfile):
+@import_or_fail("cftime")
+def test_write_prediction(mock_ncfile, pytestconfig):
+
+    from modulus.utils.corrdiff import NetCDFWriter
+
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
     lon = np.array([[5.0, 6.0], [7.0, 8.0]])
     input_channels = []
@@ -149,7 +164,11 @@ def test_write_prediction(mock_ncfile):
     )
 
 
-def test_write_time(mock_ncfile):
+@import_or_fail("cftime")
+def test_write_time(mock_ncfile, pytestconfig):
+
+    from modulus.utils.corrdiff import NetCDFWriter
+
     lat = np.array([[1.0, 2.0], [3.0, 4.0]])
     lon = np.array([[5.0, 6.0], [7.0, 8.0]])
     input_channels = []

--- a/test/utils/corrdiff/test_time_range.py
+++ b/test/utils/corrdiff/test_time_range.py
@@ -14,17 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from modulus.utils.corrdiff import get_time_from_range
+from pytest_utils import import_or_fail
 
 
-def test_default_interval():
+@import_or_fail("cftime")
+def test_default_interval(pytestconfig):
+
+    from modulus.utils.corrdiff import get_time_from_range
+
     times_range = ["2024-01-01T00:00:00", "2024-01-01T01:00:00"]
     expected = ["2024-01-01T00:00:00", "2024-01-01T01:00:00"]
     result = get_time_from_range(times_range)
     assert result == expected
 
 
-def test_hourly_interval():
+@import_or_fail("cftime")
+def test_hourly_interval(pytestconfig):
+
+    from modulus.utils.corrdiff import get_time_from_range
+
     times_range = ["2024-01-01T00:00:00", "2024-01-01T03:00:00", 1]
     expected = [
         "2024-01-01T00:00:00",
@@ -36,21 +44,33 @@ def test_hourly_interval():
     assert result == expected
 
 
-def test_custom_interval():
+@import_or_fail("cftime")
+def test_custom_interval(pytestconfig):
+
+    from modulus.utils.corrdiff import get_time_from_range
+
     times_range = ["2024-01-01T00:00:00", "2024-01-01T03:00:00", 2]
     expected = ["2024-01-01T00:00:00", "2024-01-01T02:00:00"]
     result = get_time_from_range(times_range)
     assert result == expected
 
 
-def test_no_interval_provided():
+@import_or_fail("cftime")
+def test_no_interval_provided(pytestconfig):
+
+    from modulus.utils.corrdiff import get_time_from_range
+
     times_range = ["2024-01-01T00:00:00", "2024-01-01T02:00:00"]
     expected = ["2024-01-01T00:00:00", "2024-01-01T01:00:00", "2024-01-01T02:00:00"]
     result = get_time_from_range(times_range)
     assert result == expected
 
 
-def test_same_start_end_time():
+@import_or_fail("cftime")
+def test_same_start_end_time(pytestconfig):
+
+    from modulus.utils.corrdiff import get_time_from_range
+
     times_range = ["2024-01-01T00:00:00", "2024-01-01T00:00:00"]
     expected = ["2024-01-01T00:00:00"]
     result = get_time_from_range(times_range)

--- a/test/utils/generative/test_deterministic_sampler.py
+++ b/test/utils/generative/test_deterministic_sampler.py
@@ -17,8 +17,7 @@
 
 import pytest
 import torch
-
-from modulus.utils.generative import deterministic_sampler
+from pytest_utils import import_or_fail
 
 
 # Mock a minimal net class for testing
@@ -41,7 +40,11 @@ def mock_net():
 
 
 # Basic functionality test
-def test_deterministic_sampler_output_type_and_shape(mock_net):
+@import_or_fail("cftime")
+def test_deterministic_sampler_output_type_and_shape(mock_net, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     output = deterministic_sampler(net=mock_net, latents=latents, img_lr=img_lr)
@@ -50,8 +53,12 @@ def test_deterministic_sampler_output_type_and_shape(mock_net):
 
 
 # Test for parameter validation
+@import_or_fail("cftime")
 @pytest.mark.parametrize("solver", ["invalid_solver", "euler", "heun"])
-def test_deterministic_sampler_solver_validation(mock_net, solver):
+def test_deterministic_sampler_solver_validation(mock_net, solver, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     if solver == "invalid_solver":
         with pytest.raises(ValueError):
             deterministic_sampler(
@@ -71,7 +78,11 @@ def test_deterministic_sampler_solver_validation(mock_net, solver):
 
 
 # Test for edge cases
-def test_deterministic_sampler_edge_cases(mock_net):
+@import_or_fail("cftime")
+def test_deterministic_sampler_edge_cases(mock_net, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     # Test with extreme rho values, zero noise levels, etc.
@@ -82,8 +93,12 @@ def test_deterministic_sampler_edge_cases(mock_net):
 
 
 # Test discretization
+@import_or_fail("cftime")
 @pytest.mark.parametrize("discretization", ["vp", "ve", "iddpm", "edm"])
-def test_deterministic_sampler_discretization(mock_net, discretization):
+def test_deterministic_sampler_discretization(mock_net, discretization, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     output = deterministic_sampler(
@@ -93,8 +108,12 @@ def test_deterministic_sampler_discretization(mock_net, discretization):
 
 
 # Test schedule
+@import_or_fail("cftime")
 @pytest.mark.parametrize("schedule", ["vp", "ve", "linear"])
-def test_deterministic_sampler_schedule(mock_net, schedule):
+def test_deterministic_sampler_schedule(mock_net, schedule, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     output = deterministic_sampler(
@@ -104,8 +123,12 @@ def test_deterministic_sampler_schedule(mock_net, schedule):
 
 
 # Test number of steps
+@import_or_fail("cftime")
 @pytest.mark.parametrize("num_steps", [1, 5, 18])
-def test_deterministic_sampler_num_steps(mock_net, num_steps):
+def test_deterministic_sampler_num_steps(mock_net, num_steps, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     output = deterministic_sampler(
@@ -115,8 +138,14 @@ def test_deterministic_sampler_num_steps(mock_net, num_steps):
 
 
 # Test sigma
+@import_or_fail("cftime")
 @pytest.mark.parametrize("sigma_min, sigma_max", [(0.001, 0.01), (1.0, 1.5)])
-def test_deterministic_sampler_sigma_boundaries(mock_net, sigma_min, sigma_max):
+def test_deterministic_sampler_sigma_boundaries(
+    mock_net, sigma_min, sigma_max, pytestconfig
+):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     output = deterministic_sampler(
@@ -130,8 +159,12 @@ def test_deterministic_sampler_sigma_boundaries(mock_net, sigma_min, sigma_max):
 
 
 # Test error handling
+@import_or_fail("cftime")
 @pytest.mark.parametrize("scaling", ["invalid_scaling", "vp", "none"])
-def test_deterministic_sampler_scaling_validation(mock_net, scaling):
+def test_deterministic_sampler_scaling_validation(mock_net, scaling, pytestconfig):
+
+    from modulus.utils.generative import deterministic_sampler
+
     latents = torch.randn(1, 3, 64, 64)
     img_lr = torch.randn(1, 3, 64, 64)
     if scaling == "invalid_scaling":

--- a/test/utils/generative/test_format_time.py
+++ b/test/utils/generative/test_format_time.py
@@ -15,11 +15,15 @@
 # limitations under the License.
 
 
-from modulus.utils.generative import format_time, format_time_brief
+from pytest_utils import import_or_fail
 
 
 # Test format_time function
-def test_format_time():
+@import_or_fail("cftime")
+def test_format_time(pytestconfig):
+
+    from modulus.utils.generative import format_time
+
     assert format_time(59) == "59s"
     assert format_time(60) == "1m 00s"
     assert format_time(3599) == "59m 59s"
@@ -31,7 +35,11 @@ def test_format_time():
 
 
 # Test format_time_brief function
-def test_format_time_brief():
+@import_or_fail("cftime")
+def test_format_time_brief(pytestconfig):
+
+    from modulus.utils.generative import format_time_brief
+
     assert format_time_brief(59) == "59s"
     assert format_time_brief(60) == "1m 00s"
     assert format_time_brief(3600) == "1h 00m"

--- a/test/utils/generative/test_parse_int_list.py
+++ b/test/utils/generative/test_parse_int_list.py
@@ -14,10 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from modulus.utils.generative import parse_int_list
+from pytest_utils import import_or_fail
 
 
-def test_parse_int_list():
+@import_or_fail("cftime")
+def test_parse_int_list(pytestconfig):
+
+    from modulus.utils.generative import parse_int_list
+
     # Test parsing a simple comma-separated list
     input_str = "1,2,5,7,10"
     expected_result = [1, 2, 5, 7, 10]

--- a/test/utils/generative/test_parse_time.py
+++ b/test/utils/generative/test_parse_time.py
@@ -20,8 +20,6 @@ import pytest
 import yaml
 from pytest_utils import import_or_fail
 
-from modulus.utils.generative import convert_datetime_to_cftime
-
 cftime = pytest.importorskip("cftime")
 
 # ruff: noqa: S101  # TODo remove exception
@@ -38,6 +36,9 @@ def test_datetime_yaml():
 @import_or_fail("cftime")
 def test_convert_to_cftime(pytestconfig):
     """test parse time"""
+
+    from modulus.utils.generative import convert_datetime_to_cftime
+
     dt = datetime.datetime(2011, 1, 1)
     expected = cftime.DatetimeGregorian(2011, 1, 1)
     assert convert_datetime_to_cftime(dt) == expected

--- a/test/utils/generative/test_stochastic_sampler.py
+++ b/test/utils/generative/test_stochastic_sampler.py
@@ -17,9 +17,8 @@
 from typing import Optional
 
 import torch
+from pytest_utils import import_or_fail
 from torch import Tensor
-
-from modulus.utils.generative import image_batching, image_fuse, stochastic_sampler
 
 
 # Mock network class
@@ -44,7 +43,11 @@ class MockNet:
 
 
 # The test function for edm_sampler
-def test_stochastic_sampler():
+@import_or_fail("cftime")
+def test_stochastic_sampler(pytestconfig):
+
+    from modulus.utils.generative import stochastic_sampler
+
     net = MockNet()
     latents = torch.randn(2, 3, 448, 448)  # Mock latents
     img_lr = torch.randn(2, 3, 112, 112)  # Mock low-res image
@@ -121,7 +124,11 @@ def test_stochastic_sampler():
     ), "Churn output shape does not match expected shape"
 
 
-def test_image_fuse_basic():
+@import_or_fail("cftime")
+def test_image_fuse_basic(pytestconfig):
+
+    from modulus.utils.generative import image_fuse
+
     # Basic test: No overlap, no boundary, one patch
     batch_size = 1
     img_shape_x = img_shape_y = 4
@@ -147,7 +154,11 @@ def test_image_fuse_basic():
     ), "Output does not match expected output."
 
 
-def test_image_fuse_with_boundary():
+@import_or_fail("cftime")
+def test_image_fuse_with_boundary(pytestconfig):
+
+    from modulus.utils.generative import image_fuse
+
     # Test with boundary pixels
     batch_size = 1
     img_shape_x = img_shape_y = 4
@@ -175,7 +186,11 @@ def test_image_fuse_with_boundary():
     ), "Output with boundary does not match expected output."
 
 
-def test_image_fuse_with_multiple_batches():
+@import_or_fail("cftime")
+def test_image_fuse_with_multiple_batches(pytestconfig):
+
+    from modulus.utils.generative import image_fuse
+
     # Test with multiple batches
     batch_size = 2
     img_shape_x = img_shape_y = 4
@@ -220,7 +235,11 @@ def test_image_fuse_with_multiple_batches():
     ), "Output for multiple batches does not match expected output."
 
 
-def test_image_batching_basic():
+@import_or_fail("cftime")
+def test_image_batching_basic(pytestconfig):
+
+    from modulus.utils.generative import image_batching
+
     # Test with no overlap, no boundary, no input_interp
     batch_size = 1
     img_shape_x = img_shape_y = 4
@@ -246,8 +265,12 @@ def test_image_batching_basic():
     ), "Batched images do not match expected output."
 
 
-def test_image_batching_with_boundary():
+@import_or_fail("cftime")
+def test_image_batching_with_boundary(pytestconfig):
     # Test with boundary pixels, no overlap, no input_interp
+
+    from modulus.utils.generative import image_batching
+
     batch_size = 1
     img_shape_x = img_shape_y = 4
     patch_shape_x = patch_shape_y = 6
@@ -272,8 +295,12 @@ def test_image_batching_with_boundary():
     ), "Batched images with boundary do not match expected output."
 
 
-def test_image_batching_with_input_interp():
+@import_or_fail("cftime")
+def test_image_batching_with_input_interp(pytestconfig):
     # Test with input_interp tensor
+
+    from modulus.utils.generative import image_batching
+
     batch_size = 1
     img_shape_x = img_shape_y = 4
     patch_shape_x = patch_shape_y = 4

--- a/test/utils/generative/test_tuple_product.py
+++ b/test/utils/generative/test_tuple_product.py
@@ -14,12 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from modulus.utils.generative import tuple_product
+from pytest_utils import import_or_fail
 
 
 # Test tuple_product function
-def test_tuple_product():
+@import_or_fail("cftime")
+def test_tuple_product(pytestconfig):
+
+    from modulus.utils.generative import tuple_product
+
     # Test with an empty tuple
     assert tuple_product(()) == 1
 

--- a/test/utils/test_mesh_utils.py
+++ b/test/utils/test_mesh_utils.py
@@ -21,14 +21,8 @@ import urllib
 import numpy as np
 import pytest
 from pytest_utils import import_or_fail
-from stl import mesh
 
-from modulus.utils.mesh import (
-    combine_vtp_files,
-    convert_tesselated_files_in_directory,
-    sdf_to_stl,
-)
-from modulus.utils.sdf import signed_distance_field
+stl = pytest.importorskip("stl")
 
 
 @pytest.fixture
@@ -48,11 +42,16 @@ def download_stl(tmp_path):
     return file_path
 
 
-@import_or_fail(["vtk"])
+@import_or_fail(["vtk", "warp"])
 def test_mesh_utils(tmp_path, pytestconfig):
     """Tests the utility for combining VTP files and converting tesselated files."""
 
     import vtk
+
+    from modulus.utils.mesh import (
+        combine_vtp_files,
+        convert_tesselated_files_in_directory,
+    )
 
     def _create_random_vtp_mesh(num_points: int, num_triangles: int, dir: str) -> tuple:
         """
@@ -180,6 +179,13 @@ def test_mesh_utils(tmp_path, pytestconfig):
 @import_or_fail(["warp", "skimage", "stl"])
 @pytest.mark.parametrize("backend", ["warp", "skimage"])
 def test_stl_gen(pytestconfig, backend, download_stl, tmp_path):
+
+    from stl import mesh
+
+    from modulus.utils.mesh import (
+        sdf_to_stl,
+    )
+    from modulus.utils.sdf import signed_distance_field
 
     bunny_mesh = mesh.Mesh.from_file(str(download_stl))
 

--- a/test/utils/test_sdf.py
+++ b/test/utils/test_sdf.py
@@ -19,8 +19,6 @@
 import numpy as np
 from pytest_utils import import_or_fail
 
-from modulus.utils.sdf import signed_distance_field
-
 
 def tet_verts(flip_x=1):
     tet = np.array(
@@ -70,6 +68,8 @@ def tet_verts(flip_x=1):
 
 @import_or_fail("warp")
 def test_sdf(pytestconfig):
+
+    from modulus.utils.sdf import signed_distance_field
 
     tet = tet_verts()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Cleans up pyproject.toml and moves some use-case specific dependencies to optional. Applies the `@nfs_data_or_fail` and the `@import_or_fail` decorators to some of the tests that were missing this, and also updates the contribution guide to encourage their usage. 

Also closes some issues.

Closes: https://github.com/NVIDIA/modulus/issues/734
Closes: https://github.com/NVIDIA/modulus/issues/491

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->