### PR TITLE
Dockerfile changes to handle onnxruntime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,10 +100,16 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] && [ "$DGL_ARM64_WHEEL" != "unknown
     fi
 
 # Install onnx
+# Need to install Onnx from custom wheel as Onnx does not support ARM wheels
+ARG ONNXRUNTIME_ARM64_WHEEL
+ENV ONNXRUNTIME_ARM64_WHEEL=${ONNXRUNTIME_ARM64_WHEEL:-unknown}
+
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         pip install "onnxruntime-gpu>1.19.0"; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ] && [ "$ONNXRUNTIME_ARM64_WHEEL" != "unknown" ]; then \
+	pip install --no-cache-dir --no-deps /modulus/deps/${ONNXRUNTIME_ARM64_WHEEL}; \
     else \
-        echo "Skipping!"; \
+        echo "Skipping onnxruntime_gpu install."; \
     fi
 
 # cleanup of stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] && [ "$DGL_ARM64_WHEEL" != "unknown
 
 # Install onnx
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        pip install "onnxruntime-gpu>1.19.0"
+        pip install "onnxruntime-gpu>1.19.0"; \
     else \
         echo "Skipping!"; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] && [ "$DGL_ARM64_WHEEL" != "unknown
     fi
 
 # Install onnx
-RUN pip install "onnxruntime-gpu>1.19.0"
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        pip install "onnxruntime-gpu>1.19.0"
+    else \
+        echo "Skipping!"; \
+    fi
 
 # cleanup of stage
 RUN rm -rf /modulus/

--- a/test/deploy/ort_utils.py
+++ b/test/deploy/ort_utils.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from packaging.version import Version
+
+try:
+    import onnxruntime as ort
+except ImportError:
+    ort = None
+
+
+def check_ort_version():
+    required_version = Version("1.19.0")
+
+    if ort is None:
+        return pytest.mark.skipif(
+            True,
+            reason="Proper ONNX runtime is not installed. 'pip install onnxruntime onnxruntime_gpu'",
+        )
+
+    installed_version = Version(ort.__version__)
+
+    if installed_version < required_version:
+        return pytest.mark.skipif(
+            True,
+            reason="Must install ORT 1.19.0 or later. Other versions might work, but are not \
+        tested. If using other versions, ensure that the fix here \
+        https://github.com/microsoft/onnxruntime/pull/15662 is present. \
+        If the onnxruntime-gpu wheel is not available, please build from source.",
+        )
+
+    return pytest.mark.skipif(False, reason="")

--- a/test/deploy/test_onnx_fft.py
+++ b/test/deploy/test_onnx_fft.py
@@ -32,31 +32,35 @@ except ImportError:
 
 from typing import Tuple
 
+from packaging.version import Version
+
 from modulus.deploy.onnx import export_to_onnx_stream, run_onnx_inference
 
 Tensor = torch.Tensor
 logger = logging.getLogger("__name__")
 
 
-# TODO(akamenev): remove once the bug below is fixed.
-# Version "1.14.0" is the custom local build where the bug is fixed.
 def check_ort_version():
+    required_version = Version("1.19.0")
+
     if ort is None:
         return pytest.mark.skipif(
             True,
             reason="Proper ONNX runtime is not installed. 'pip install onnxruntime onnxruntime_gpu'",
         )
-    elif ort.__version__ != "1.18.0":
+
+    installed_version = Version(ort.__version__)
+
+    if installed_version < required_version:
         return pytest.mark.skipif(
             True,
-            reason="Must install ORT 1.18.0. Other versions might work, but are not \
+            reason="Must install ORT 1.19.0 or later. Other versions might work, but are not \
         tested. If using other versions, ensure that the fix here \
         https://github.com/microsoft/onnxruntime/pull/15662 is present. \
-        If the onnxruntime-gpu wheel is not available, please build from source. \
-        For 1.18.0, one can use https://github.com/microsoft/onnxruntime/commit/4ea54b82f9debd70e46ea0a789e7aafe05d5b983",
+        If the onnxruntime-gpu wheel is not available, please build from source.",
         )
-    else:
-        return pytest.mark.skipif(False, reason="")
+
+    return pytest.mark.skipif(False, reason="")
 
 
 @pytest.fixture

--- a/test/deploy/test_onnx_fft.py
+++ b/test/deploy/test_onnx_fft.py
@@ -32,35 +32,12 @@ except ImportError:
 
 from typing import Tuple
 
-from packaging.version import Version
+from ort_utils import check_ort_version
 
 from modulus.deploy.onnx import export_to_onnx_stream, run_onnx_inference
 
 Tensor = torch.Tensor
 logger = logging.getLogger("__name__")
-
-
-def check_ort_version():
-    required_version = Version("1.19.0")
-
-    if ort is None:
-        return pytest.mark.skipif(
-            True,
-            reason="Proper ONNX runtime is not installed. 'pip install onnxruntime onnxruntime_gpu'",
-        )
-
-    installed_version = Version(ort.__version__)
-
-    if installed_version < required_version:
-        return pytest.mark.skipif(
-            True,
-            reason="Must install ORT 1.19.0 or later. Other versions might work, but are not \
-        tested. If using other versions, ensure that the fix here \
-        https://github.com/microsoft/onnxruntime/pull/15662 is present. \
-        If the onnxruntime-gpu wheel is not available, please build from source.",
-        )
-
-    return pytest.mark.skipif(False, reason="")
 
 
 @pytest.fixture

--- a/test/deploy/test_onnx_utils.py
+++ b/test/deploy/test_onnx_utils.py
@@ -27,36 +27,13 @@ except ImportError:
 
 from pathlib import Path
 
-from packaging.version import Version
+from ort_utils import check_ort_version
 
 from modulus.deploy.onnx import export_to_onnx_stream, run_onnx_inference
 from modulus.models.mlp import FullyConnected
 
 Tensor = torch.Tensor
 logger = logging.getLogger("__name__")
-
-
-def check_ort_version():
-    required_version = Version("1.19.0")
-
-    if ort is None:
-        return pytest.mark.skipif(
-            True,
-            reason="Proper ONNX runtime is not installed. 'pip install onnxruntime onnxruntime_gpu'",
-        )
-
-    installed_version = Version(ort.__version__)
-
-    if installed_version < required_version:
-        return pytest.mark.skipif(
-            True,
-            reason="Must install ORT 1.19.0 or later. Other versions might work, but are not \
-        tested. If using other versions, ensure that the fix here \
-        https://github.com/microsoft/onnxruntime/pull/15662 is present. \
-        If the onnxruntime-gpu wheel is not available, please build from source.",
-        )
-
-    return pytest.mark.skipif(False, reason="")
 
 
 @pytest.fixture(params=["modulus", "pytorch"])

--- a/test/deploy/test_onnx_utils.py
+++ b/test/deploy/test_onnx_utils.py
@@ -27,6 +27,8 @@ except ImportError:
 
 from pathlib import Path
 
+from packaging.version import Version
+
 from modulus.deploy.onnx import export_to_onnx_stream, run_onnx_inference
 from modulus.models.mlp import FullyConnected
 
@@ -34,25 +36,27 @@ Tensor = torch.Tensor
 logger = logging.getLogger("__name__")
 
 
-# TODO(akamenev): remove once the bug below is fixed.
-# Version "1.14.0" is the custom local build where the bug is fixed.
 def check_ort_version():
+    required_version = Version("1.19.0")
+
     if ort is None:
         return pytest.mark.skipif(
             True,
             reason="Proper ONNX runtime is not installed. 'pip install onnxruntime onnxruntime_gpu'",
         )
-    elif ort.__version__ != "1.18.0":
+
+    installed_version = Version(ort.__version__)
+
+    if installed_version < required_version:
         return pytest.mark.skipif(
             True,
-            reason="Must install ORT 1.18.0. Other versions might work, but are not \
+            reason="Must install ORT 1.19.0 or later. Other versions might work, but are not \
         tested. If using other versions, ensure that the fix here \
         https://github.com/microsoft/onnxruntime/pull/15662 is present. \
-        If the onnxruntime-gpu wheel is not available, please build from source. \
-        For 1.18.0, one can use https://github.com/microsoft/onnxruntime/commit/4ea54b82f9debd70e46ea0a789e7aafe05d5b983",
+        If the onnxruntime-gpu wheel is not available, please build from source.",
         )
-    else:
-        return pytest.mark.skipif(False, reason="")
+
+    return pytest.mark.skipif(False, reason="")
 
 
 @pytest.fixture(params=["modulus", "pytorch"])


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Changes to Dockerfile and tests to handle onnxruntime dependency. 

Onnx is still not shipping arm wheels, hence the installation from a pre-built wheel. Additionally, the tests can now be safely changed to support any onnxruntime version > 1.19.0 as the change is upstreamed. 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->